### PR TITLE
Fixing bq tests on arm64

### DIFF
--- a/pkg/warehouse/bigquery/driver_test.go
+++ b/pkg/warehouse/bigquery/driver_test.go
@@ -95,6 +95,7 @@ func createEmulatorDriver(t *testing.T) testDriverConfig {
      tables: []
 `)),
 		tcbigquery.WithProjectID(projectID),
+		testcontainers.WithImagePlatform("linux/amd64"), // Force AMD64 platform for ARM64 compatibility
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
For now we can workaround it like that to not spend too much time on setting up separate environment. All tests pass on macos with that change. 