### PR TITLE
Refactor queue config: nest object_storage under queue

### DIFF
--- a/docs/docs/articles/production-operations.md
+++ b/docs/docs/articles/production-operations.md
@@ -30,20 +30,20 @@ YAML (`config.yaml`):
 
 ```yaml
 queue:
-  backend: objectstorage
-  object_prefix: d8a/dev/queue
-
-object_storage:
-  type: s3
-  s3:
-    host: 127.0.0.1
-    port: 9000
-    protocol: http
-    bucket: d8a-queue
-    access_key: minioadmin
-    secret_key: minioadmin
-    region: us-east-1
-    create_bucket: true
+  backend: object_storage
+  
+  object_storage:
+    prefix: d8a/dev/queue
+    type: s3
+    s3:
+      host: 127.0.0.1
+      port: 9000
+      protocol: http
+      bucket: d8a-queue
+      access_key: minioadmin
+      secret_key: minioadmin
+      region: us-east-1
+      create_bucket: true
 ```
 
 Run receiver(s):
@@ -60,5 +60,5 @@ go run . worker --config config.yaml --storage-bolt-directory ./state
 
 Notes:
 
-- Use `queue.object_prefix` to namespace environments (prevents cross-talk within a shared bucket).
+- Use `queue.object_storage.prefix` to namespace environments (prevents cross-talk within a shared bucket).
 - The system is at-least-once: tasks can be replayed if the worker crashes after processing but before deletion.

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -319,28 +319,28 @@ var queueBackendFlag *cli.StringFlag = &cli.StringFlag{
 var queueObjectPrefixFlag *cli.StringFlag = &cli.StringFlag{
 	Name:    "queue-object-prefix",
 	Usage:   "Object storage prefix/namespace for queue objects (only used for objectstorage backend)",
-	Sources: defaultSourceChain("QUEUE_OBJECT_PREFIX", "queue.object_prefix"),
+	Sources: defaultSourceChain("QUEUE_OBJECT_PREFIX", "queue.object_storage.prefix"),
 	Value:   "d8a/queue",
 }
 
 var queueObjectStorageMinIntervalFlag *cli.DurationFlag = &cli.DurationFlag{
 	Name:    "queue-objectstorage-min-interval",
 	Usage:   "Minimum polling interval for objectstorage queue consumer (only used for objectstorage backend)",
-	Sources: defaultSourceChain("QUEUE_OBJECTSTORAGE_MIN_INTERVAL", "queue.objectstorage_min_interval"),
+	Sources: defaultSourceChain("QUEUE_OBJECTSTORAGE_MIN_INTERVAL", "queue.object_storage.min_interval"),
 	Value:   5 * time.Second,
 }
 
 var queueObjectStorageMaxIntervalFlag *cli.DurationFlag = &cli.DurationFlag{
 	Name:    "queue-objectstorage-max-interval",
 	Usage:   "Maximum polling interval for objectstorage queue consumer exponential backoff (only used for objectstorage backend)", //nolint:lll // it's a description
-	Sources: defaultSourceChain("QUEUE_OBJECTSTORAGE_MAX_INTERVAL", "queue.objectstorage_max_interval"),
+	Sources: defaultSourceChain("QUEUE_OBJECTSTORAGE_MAX_INTERVAL", "queue.object_storage.max_interval"),
 	Value:   1 * time.Minute,
 }
 
 var queueObjectStorageIntervalExpFactorFlag *cli.Float64Flag = &cli.Float64Flag{
 	Name:    "queue-objectstorage-interval-exp-factor",
 	Usage:   "Exponential backoff factor for objectstorage queue consumer polling interval (only used for objectstorage backend)", //nolint:lll // it's a description
-	Sources: defaultSourceChain("QUEUE_OBJECTSTORAGE_INTERVAL_EXP_FACTOR", "queue.objectstorage_interval_exp_factor"),
+	Sources: defaultSourceChain("QUEUE_OBJECTSTORAGE_INTERVAL_EXP_FACTOR", "queue.object_storage.interval_exp_factor"),
 	Value:   1.5,
 }
 
@@ -349,7 +349,7 @@ var queueObjectStorageMaxItemsToReadAtOnceFlag *cli.IntFlag = &cli.IntFlag{
 	Usage: "Maximum number of items to read in one batch from objectstorage queue (only used for objectstorage backend)", //nolint:lll // it's a description
 	Sources: defaultSourceChain(
 		"QUEUE_OBJECTSTORAGE_MAX_ITEMS_TO_READ_AT_ONCE",
-		"queue.objectstorage_max_items_to_read_at_once",
+		"queue.object_storage.max_items_to_read_at_once",
 	),
 	Value: 1000,
 }
@@ -357,77 +357,77 @@ var queueObjectStorageMaxItemsToReadAtOnceFlag *cli.IntFlag = &cli.IntFlag{
 var objectStorageTypeFlag *cli.StringFlag = &cli.StringFlag{
 	Name:    "object-storage-type",
 	Usage:   "Object storage type (s3 or gcs)",
-	Sources: defaultSourceChain("OBJECT_STORAGE_TYPE", "object_storage.type"),
+	Sources: defaultSourceChain("OBJECT_STORAGE_TYPE", "queue.object_storage.type"),
 }
 
 var objectStorageS3HostFlag *cli.StringFlag = &cli.StringFlag{
 	Name:    "object-storage-s3-host",
 	Usage:   "S3/MinIO host (only used when object-storage-type=s3)",
-	Sources: defaultSourceChain("OBJECT_STORAGE_S3_HOST", "object_storage.s3.host"),
+	Sources: defaultSourceChain("OBJECT_STORAGE_S3_HOST", "queue.object_storage.s3.host"),
 }
 
 var objectStorageS3PortFlag *cli.IntFlag = &cli.IntFlag{
 	Name:    "object-storage-s3-port",
 	Usage:   "S3/MinIO port (only used when object-storage-type=s3)",
-	Sources: defaultSourceChain("OBJECT_STORAGE_S3_PORT", "object_storage.s3.port"),
+	Sources: defaultSourceChain("OBJECT_STORAGE_S3_PORT", "queue.object_storage.s3.port"),
 	Value:   9000,
 }
 
 var objectStorageS3BucketFlag *cli.StringFlag = &cli.StringFlag{
 	Name:    "object-storage-s3-bucket",
 	Usage:   "S3/MinIO bucket name (only used when object-storage-type=s3)",
-	Sources: defaultSourceChain("OBJECT_STORAGE_S3_BUCKET", "object_storage.s3.bucket"),
+	Sources: defaultSourceChain("OBJECT_STORAGE_S3_BUCKET", "queue.object_storage.s3.bucket"),
 }
 
 var objectStorageS3AccessKeyFlag *cli.StringFlag = &cli.StringFlag{
 	Name:    "object-storage-s3-access-key",
 	Usage:   "S3/MinIO access key (only used when object-storage-type=s3)",
-	Sources: defaultSourceChain("OBJECT_STORAGE_S3_ACCESS_KEY", "object_storage.s3.access_key"),
+	Sources: defaultSourceChain("OBJECT_STORAGE_S3_ACCESS_KEY", "queue.object_storage.s3.access_key"),
 }
 
 var objectStorageS3SecretKeyFlag *cli.StringFlag = &cli.StringFlag{
 	Name:    "object-storage-s3-secret-key",
 	Usage:   "S3/MinIO secret key (only used when object-storage-type=s3)",
-	Sources: defaultSourceChain("OBJECT_STORAGE_S3_SECRET_KEY", "object_storage.s3.secret_key"),
+	Sources: defaultSourceChain("OBJECT_STORAGE_S3_SECRET_KEY", "queue.object_storage.s3.secret_key"),
 }
 
 var objectStorageS3RegionFlag *cli.StringFlag = &cli.StringFlag{
 	Name:    "object-storage-s3-region",
 	Usage:   "S3 region (only used when object-storage-type=s3)",
-	Sources: defaultSourceChain("OBJECT_STORAGE_S3_REGION", "object_storage.s3.region"),
+	Sources: defaultSourceChain("OBJECT_STORAGE_S3_REGION", "queue.object_storage.s3.region"),
 	Value:   "us-east-1",
 }
 
 var objectStorageS3ProtocolFlag *cli.StringFlag = &cli.StringFlag{
 	Name:    "object-storage-s3-protocol",
 	Usage:   "S3 endpoint protocol (http or https; only used when object-storage-type=s3)",
-	Sources: defaultSourceChain("OBJECT_STORAGE_S3_PROTOCOL", "object_storage.s3.protocol"),
+	Sources: defaultSourceChain("OBJECT_STORAGE_S3_PROTOCOL", "queue.object_storage.s3.protocol"),
 	Value:   "http",
 }
 
 var objectStorageS3CreateBucketFlag *cli.BoolFlag = &cli.BoolFlag{
 	Name:    "object-storage-s3-create-bucket",
 	Usage:   "Create bucket on startup if missing (only used when object-storage-type=s3)",
-	Sources: defaultSourceChain("OBJECT_STORAGE_S3_CREATE_BUCKET", "object_storage.s3.create_bucket"),
+	Sources: defaultSourceChain("OBJECT_STORAGE_S3_CREATE_BUCKET", "queue.object_storage.s3.create_bucket"),
 	Value:   false,
 }
 
 var objectStorageGCSBucketFlag *cli.StringFlag = &cli.StringFlag{
 	Name:    "object-storage-gcs-bucket",
 	Usage:   "GCS bucket name (only used when object-storage-type=gcs)",
-	Sources: defaultSourceChain("OBJECT_STORAGE_GCS_BUCKET", "object_storage.gcs.bucket"),
+	Sources: defaultSourceChain("OBJECT_STORAGE_GCS_BUCKET", "queue.object_storage.gcs.bucket"),
 }
 
 var objectStorageGCSProjectFlag *cli.StringFlag = &cli.StringFlag{
 	Name:    "object-storage-gcs-project",
 	Usage:   "GCS project ID (optional; only used when object-storage-type=gcs)",
-	Sources: defaultSourceChain("OBJECT_STORAGE_GCS_PROJECT", "object_storage.gcs.project"),
+	Sources: defaultSourceChain("OBJECT_STORAGE_GCS_PROJECT", "queue.object_storage.gcs.project"),
 }
 
 var objectStorageGCSCredsJSONFlag *cli.StringFlag = &cli.StringFlag{
 	Name:    "object-storage-gcs-creds-json",
 	Usage:   "GCS credentials JSON (raw or base64); empty uses ADC (only used when object-storage-type=gcs)",
-	Sources: defaultSourceChain("OBJECT_STORAGE_GCS_CREDS_JSON", "object_storage.gcs.creds_json"),
+	Sources: defaultSourceChain("OBJECT_STORAGE_GCS_CREDS_JSON", "queue.object_storage.gcs.creds_json"),
 }
 
 var storageSpoolEnabledFlag *cli.BoolFlag = &cli.BoolFlag{

--- a/pkg/e2e/utils_test.go
+++ b/pkg/e2e/utils_test.go
@@ -653,47 +653,47 @@ func (b *testConfigBuilder) buildYAML() string {
 	if b.queueBackend == "objectstorage" {
 		content.WriteString("queue:\n")
 		fmt.Fprintf(&content, "  backend: %s\n", b.queueBackend)
-		if b.queueObjectPrefix != "" {
-			fmt.Fprintf(&content, "  object_prefix: %s\n", b.queueObjectPrefix)
-		}
-		if b.queueObjectStorageMinInterval > 0 {
-			fmt.Fprintf(&content, "  objectstorage_min_interval: %s\n", b.queueObjectStorageMinInterval)
-		}
-		if b.queueObjectStorageMaxInterval > 0 {
-			fmt.Fprintf(&content, "  objectstorage_max_interval: %s\n", b.queueObjectStorageMaxInterval)
-		}
-		if b.queueObjectStorageIntervalExpFactor > 0 {
-			fmt.Fprintf(&content, "  objectstorage_interval_exp_factor: %g\n", b.queueObjectStorageIntervalExpFactor)
-		}
-		if b.queueObjectStorageMaxItemsToReadAtOnce > 0 {
-			fmt.Fprintf(&content, "  objectstorage_max_items_to_read_at_once: %d\n", b.queueObjectStorageMaxItemsToReadAtOnce)
-		}
 		content.WriteString("\n")
 
-		// Object storage configuration
-		content.WriteString("object_storage:\n")
-		fmt.Fprintf(&content, "  type: %s\n", b.objectStorageType)
-		content.WriteString("  s3:\n")
+		// Object storage configuration (nested under queue)
+		content.WriteString("  object_storage:\n")
+		if b.queueObjectPrefix != "" {
+			fmt.Fprintf(&content, "    prefix: %s\n", b.queueObjectPrefix)
+		}
+		if b.queueObjectStorageMinInterval > 0 {
+			fmt.Fprintf(&content, "    min_interval: %s\n", b.queueObjectStorageMinInterval)
+		}
+		if b.queueObjectStorageMaxInterval > 0 {
+			fmt.Fprintf(&content, "    max_interval: %s\n", b.queueObjectStorageMaxInterval)
+		}
+		if b.queueObjectStorageIntervalExpFactor > 0 {
+			fmt.Fprintf(&content, "    interval_exp_factor: %g\n", b.queueObjectStorageIntervalExpFactor)
+		}
+		if b.queueObjectStorageMaxItemsToReadAtOnce > 0 {
+			fmt.Fprintf(&content, "    max_items_to_read_at_once: %d\n", b.queueObjectStorageMaxItemsToReadAtOnce)
+		}
+		fmt.Fprintf(&content, "    type: %s\n", b.objectStorageType)
+		content.WriteString("    s3:\n")
 		if b.objectStorageS3Host != "" {
-			fmt.Fprintf(&content, "    host: %s\n", b.objectStorageS3Host)
+			fmt.Fprintf(&content, "      host: %s\n", b.objectStorageS3Host)
 		}
 		if b.objectStorageS3Port != nil {
-			fmt.Fprintf(&content, "    port: %d\n", *b.objectStorageS3Port)
+			fmt.Fprintf(&content, "      port: %d\n", *b.objectStorageS3Port)
 		}
 		if b.objectStorageS3AccessKey != "" {
-			fmt.Fprintf(&content, "    access_key: %s\n", b.objectStorageS3AccessKey)
+			fmt.Fprintf(&content, "      access_key: %s\n", b.objectStorageS3AccessKey)
 		}
 		if b.objectStorageS3SecretKey != "" {
-			fmt.Fprintf(&content, "    secret_key: %s\n", b.objectStorageS3SecretKey)
+			fmt.Fprintf(&content, "      secret_key: %s\n", b.objectStorageS3SecretKey)
 		}
 		if b.objectStorageS3Bucket != "" {
-			fmt.Fprintf(&content, "    bucket: %s\n", b.objectStorageS3Bucket)
+			fmt.Fprintf(&content, "      bucket: %s\n", b.objectStorageS3Bucket)
 		}
 		if b.objectStorageS3CreateBucket != nil {
-			fmt.Fprintf(&content, "    create_bucket: %v\n", *b.objectStorageS3CreateBucket)
+			fmt.Fprintf(&content, "      create_bucket: %v\n", *b.objectStorageS3CreateBucket)
 		}
-		content.WriteString("    region: us-east-1\n")
-		content.WriteString("    protocol: http\n\n")
+		content.WriteString("      region: us-east-1\n")
+		content.WriteString("      protocol: http\n\n")
 	}
 
 	if b.port != nil {
@@ -817,7 +817,7 @@ func TestConfigBuilder(t *testing.T) {
 				t.Error("config should contain property field")
 			}
 
-			// For objectstorage tests, verify queue and object_storage sections
+			// For objectstorage tests, verify queue and nested object_storage sections
 			if tt.name == "objectstorage queue config" {
 				if !strings.Contains(configStr, "queue:") {
 					t.Error("objectstorage config should contain queue section")
@@ -825,17 +825,20 @@ func TestConfigBuilder(t *testing.T) {
 				if !strings.Contains(configStr, "backend: objectstorage") {
 					t.Error("queue section should specify objectstorage backend")
 				}
-				if !strings.Contains(configStr, "object_storage:") {
-					t.Error("objectstorage config should contain object_storage section")
+				if !strings.Contains(configStr, "  object_storage:") {
+					t.Error("objectstorage config should contain nested object_storage section under queue")
 				}
-				if !strings.Contains(configStr, "host: localhost") {
+				if !strings.Contains(configStr, "    prefix: d8a/queue") {
+					t.Error("object_storage section should contain prefix field")
+				}
+				if !strings.Contains(configStr, "      host: localhost") {
 					t.Error("object_storage.s3 section should contain host")
 				}
-				if !strings.Contains(configStr, "port: 9000") {
+				if !strings.Contains(configStr, "      port: 9000") {
 					t.Error("object_storage.s3 section should contain port")
 				}
-				if !strings.Contains(configStr, "objectstorage_min_interval: 10ms") {
-					t.Error("queue section should contain objectstorage_min_interval")
+				if !strings.Contains(configStr, "    min_interval: 10ms") {
+					t.Error("object_storage section should contain min_interval")
 				}
 			}
 


### PR DESCRIPTION
Move object_storage configuration from a top-level YAML key into queue.object_storage.

Breaking change: users must update config.yaml to use the new layout:
  queue.object_storage.{prefix,type,s3.*,gcs.*} instead of
  object_prefix / object_storage.{type,s3.*,gcs.*}

Backend value also renamed: objectstorage -> object_storage.