### PR TITLE
fix: normalize referrer host matching for SMT

### DIFF
--- a/pkg/columns/columntests/columns_test.go
+++ b/pkg/columns/columntests/columns_test.go
@@ -532,6 +532,20 @@ func TestSessionSourceMediumTerm(t *testing.T) {
 			},
 		},
 		{
+			name: "SessionSourceMediumTerm_SearchGoogle",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "https://search.google.com/search?q=keyword"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("google"),
+					s("organic"),
+					s("keyword"),
+				},
+			},
+		},
+		{
 			name: "SessionSourceMediumTerm_IlseNL",
 			hits: TestHits{TestHitOne()},
 			caseConfigFuncs: []CaseConfigFunc{
@@ -578,6 +592,20 @@ func TestSessionSourceMediumTerm(t *testing.T) {
 			hits: TestHits{TestHitOne()},
 			caseConfigFuncs: []CaseConfigFunc{
 				EnsureQueryParam(0, "dr", "https://www.linkedin.com/"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("linkedin"),
+					s("social"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_LinkedInAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.linkedin.android"),
 			},
 			expected: map[string][]*string{
 				TestHitOne().ID: {

--- a/pkg/columns/sessioncolumns/session_smt_source.go
+++ b/pkg/columns/sessioncolumns/session_smt_source.go
@@ -352,11 +352,23 @@ func NewFromRefererExactMatchCondition(
 	exactMatch string, smt func(qp url.Values) SessionSourceMediumTerm,
 ) refererCondition {
 	return func(cleanedReferer string, qp url.Values) (SessionSourceMediumTerm, bool) {
-		if cleanedReferer == exactMatch {
+		if matchesHostOrSubdomain(cleanedReferer, exactMatch) {
 			return smt(qp), true
 		}
 		return SessionSourceMediumTerm{}, false
 	}
+}
+
+func matchesHostOrSubdomain(host, pattern string) bool {
+	if host == pattern {
+		return true
+	}
+
+	if strings.Contains(pattern, "/") {
+		return false
+	}
+
+	return strings.HasSuffix(host, "."+pattern)
 }
 
 // NewSearchEngineSourceMediumTermDetector returns a new source medium term detector for search engines.


### PR DESCRIPTION
## Summary
- treat host-pattern matches as exact host or subdomain suffix for referrer-based SMT detectors
- keep path-based patterns strict to avoid broad matches
- add regression tests for `search.google.com` organic attribution and `android-app://com.linkedin.android` social attribution