### PR TITLE
fix(session): normalize android app referrer candidates

### DIFF
--- a/pkg/columns/columntests/columns_test.go
+++ b/pkg/columns/columntests/columns_test.go
@@ -616,20 +616,6 @@ func TestSessionSourceMediumTerm(t *testing.T) {
 			},
 		},
 		{
-			name: "SessionSourceMediumTerm_SlackAndroidApp",
-			hits: TestHits{TestHitOne()},
-			caseConfigFuncs: []CaseConfigFunc{
-				EnsureQueryParam(0, "dr", "android-app://com.slack/"),
-			},
-			expected: map[string][]*string{
-				TestHitOne().ID: {
-					s("slack"),
-					s("referral"),
-					s(""),
-				},
-			},
-		},
-		{
 			name: "SessionSourceMediumTerm_SearchEngine_RegexMatcher",
 			hits: TestHits{TestHitOne()},
 			caseConfigFuncs: []CaseConfigFunc{

--- a/pkg/columns/columntests/columns_test.go
+++ b/pkg/columns/columntests/columns_test.go
@@ -616,6 +616,20 @@ func TestSessionSourceMediumTerm(t *testing.T) {
 			},
 		},
 		{
+			name: "SessionSourceMediumTerm_SlackAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.slack/"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("slack"),
+					s("referral"),
+					s(""),
+				},
+			},
+		},
+		{
 			name: "SessionSourceMediumTerm_SearchEngine_RegexMatcher",
 			hits: TestHits{TestHitOne()},
 			caseConfigFuncs: []CaseConfigFunc{

--- a/pkg/columns/columntests/columns_test.go
+++ b/pkg/columns/columntests/columns_test.go
@@ -616,6 +616,272 @@ func TestSessionSourceMediumTerm(t *testing.T) {
 			},
 		},
 		{
+			name: "SessionSourceMediumTerm_TelegramAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://org.telegram.messenger"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("telegram"),
+					s("social"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_RedditAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.reddit.frontpage"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("reddit"),
+					s("social"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_MastodonAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://org.joinmastodon.android"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("mastodon"),
+					s("social"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_SlackAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.slack/"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("slack"),
+					s("social"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_WhatsAppAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.whatsapp"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("whatsapp"),
+					s("social"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_FacebookAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.facebook.katana"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("facebook"),
+					s("social"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_InstagramAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.instagram.android"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("instagram"),
+					s("social"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_TwitterAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.twitter.android"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("twitter"),
+					s("social"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_PinterestAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.pinterest"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("pinterest"),
+					s("social"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_TikTokAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.zhiliaoapp.musically"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("tiktok"),
+					s("social"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_YouTubeAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.google.android.youtube"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("youtube"),
+					s("video"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_TwitchAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://tv.twitch.android.app"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("twitch"),
+					s("video"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_GmailAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.google.android.gm"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("gmail"),
+					s("email"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_OutlookAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.microsoft.office.outlook"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("outlook"),
+					s("email"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_ChatGPTAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.openai.chatgpt"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("chatgpt"),
+					s("ai"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_GeminiAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.google.android.apps.bard"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("gemini"),
+					s("ai"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_PerplexityAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://ai.perplexity.app.android"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("perplexity"),
+					s("ai"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_ChromeAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://com.android.chrome"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("chrome"),
+					s("referral"),
+					s(""),
+				},
+			},
+		},
+		{
+			name: "SessionSourceMediumTerm_FirefoxAndroidApp",
+			hits: TestHits{TestHitOne()},
+			caseConfigFuncs: []CaseConfigFunc{
+				EnsureQueryParam(0, "dr", "android-app://org.mozilla.firefox"),
+			},
+			expected: map[string][]*string{
+				TestHitOne().ID: {
+					s("firefox"),
+					s("referral"),
+					s(""),
+				},
+			},
+		},
+		{
 			name: "SessionSourceMediumTerm_SearchEngine_RegexMatcher",
 			hits: TestHits{TestHitOne()},
 			caseConfigFuncs: []CaseConfigFunc{

--- a/pkg/columns/sessioncolumns/session_smt_source.go
+++ b/pkg/columns/sessioncolumns/session_smt_source.go
@@ -179,21 +179,14 @@ func NewCompositeSourceMediumTermDetector(detectors ...SourceMediumTermDetector)
 
 const parsedURLsMetadataKey = "session_smt_parsed_urls"
 
-const (
-	httpScheme  = "http"
-	httpsScheme = "https"
-)
-
 type parsedURLs struct {
-	pageURL            *url.URL
-	pageQP             url.Values
-	refURL             *url.URL
-	refQP              url.Values
-	refScheme          string
-	refHost            string
-	refHostNoWWW       string
-	refRaw             string
-	refMatchCandidates []string
+	pageURL      *url.URL
+	pageQP       url.Values
+	refURL       *url.URL
+	refQP        url.Values
+	refHost      string
+	refHostNoWWW string
+	refRaw       string
 }
 
 func ensureParsedURLs(event *schema.Event) *parsedURLs {
@@ -236,14 +229,12 @@ func ensureParsedURLs(event *schema.Event) *parsedURLs {
 				result.refRaw = refRaw
 				result.refURL = parsed
 				result.refQP = parsed.Query()
-				result.refScheme = strings.ToLower(parsed.Scheme)
 				result.refHost = strings.ReplaceAll(
 					strings.ToLower(parsed.Hostname()),
 					" ",
 					"-",
 				)
 				result.refHostNoWWW = trimWWW(result.refHost)
-				result.refMatchCandidates = buildReferrerMatchCandidates(parsed, result.refHost, result.refHostNoWWW)
 			}
 		}
 	}
@@ -255,69 +246,6 @@ func ensureParsedURLs(event *schema.Event) *parsedURLs {
 func trimWWW(host string) string {
 	host = strings.ToLower(host)
 	return strings.TrimPrefix(host, "www.")
-}
-
-// Build referrer match candidates for Matomo-derived source lists, which expect
-// canonical hosts or package-like suffixes such as linkedin.android.
-func buildReferrerMatchCandidates(parsed *url.URL, refHost, refHostNoWWW string) []string {
-	candidates := make([]string, 0, 4)
-	appendCandidate := func(candidate string) {
-		candidate = strings.TrimSpace(strings.ToLower(candidate))
-		if candidate == "" {
-			return
-		}
-		for _, existing := range candidates {
-			if existing == candidate {
-				return
-			}
-		}
-		candidates = append(candidates, candidate)
-	}
-
-	appendCandidate(refHost)
-	appendCandidate(refHostNoWWW)
-
-	if parsed != nil && parsed.Scheme != "" && parsed.Scheme != httpScheme && parsed.Scheme != httpsScheme {
-		for _, candidate := range hostSuffixCandidates(refHostNoWWW) {
-			appendCandidate(candidate)
-		}
-	}
-
-	return candidates
-}
-
-func hostSuffixCandidates(host string) []string {
-	parts := strings.Split(host, ".")
-	if len(parts) < 2 {
-		return nil
-	}
-
-	result := make([]string, 0, len(parts)-1)
-	for idx := 1; idx < len(parts); idx++ {
-		candidate := strings.Join(parts[idx:], ".")
-		if candidate == "" {
-			continue
-		}
-		result = append(result, candidate)
-	}
-
-	return result
-}
-
-func fallbackReferralSource(parsed *parsedURLs) string {
-	if parsed == nil {
-		return ""
-	}
-	if parsed.refScheme == "" || parsed.refScheme == httpScheme || parsed.refScheme == httpsScheme {
-		return parsed.refHostNoWWW
-	}
-	for idx := len(parsed.refMatchCandidates) - 1; idx >= 0; idx-- {
-		candidate := parsed.refMatchCandidates[idx]
-		if candidate != parsed.refHostNoWWW {
-			return candidate
-		}
-	}
-	return parsed.refHostNoWWW
 }
 
 type directSourceMediumTermDetector struct {
@@ -385,15 +313,17 @@ type fromRefererSourceMediumTermDetector struct {
 
 func (d *fromRefererSourceMediumTermDetector) Detect(event *schema.Event) (SessionSourceMediumTerm, bool) {
 	parsedURLs := ensureParsedURLs(event)
-	if len(parsedURLs.refMatchCandidates) == 0 {
+	if parsedURLs.refHost == "" {
 		return SessionSourceMediumTerm{}, false
 	}
-	for _, candidate := range parsedURLs.refMatchCandidates {
-		for _, condition := range d.conditions {
-			sourceMediumTerm, ok := condition(candidate, parsedURLs.refQP)
-			if ok {
-				return sourceMediumTerm, true
-			}
+	for _, condition := range d.conditions {
+		sourceMediumTerm, ok := condition(parsedURLs.refHost, parsedURLs.refQP)
+		if ok {
+			return sourceMediumTerm, true
+		}
+		sourceMediumTerm, ok = condition(parsedURLs.refHostNoWWW, parsedURLs.refQP)
+		if ok {
+			return sourceMediumTerm, true
 		}
 	}
 	return SessionSourceMediumTerm{}, false
@@ -684,36 +614,18 @@ func (d *genericReferralSourceMediumTermDetector) Detect(event *schema.Event) (S
 	if parsed.refHostNoWWW == "" {
 		return SessionSourceMediumTerm{}, false
 	}
-	referralSource := fallbackReferralSource(parsed)
-	if referralSource == "" {
-		return SessionSourceMediumTerm{}, false
-	}
 	if parsed.pageURL == nil {
-		if parsed.refScheme == "" || parsed.refScheme == httpScheme || parsed.refScheme == httpsScheme {
-			return SessionSourceMediumTerm{}, false
-		}
-		return SessionSourceMediumTerm{
-			Source: referralSource,
-			Medium: "referral",
-			Term:   "",
-		}, true
+		return SessionSourceMediumTerm{}, false
 	}
 	pageDomain := trimWWW(parsed.pageURL.Hostname())
 	if pageDomain == "" {
-		if parsed.refScheme == "" || parsed.refScheme == httpScheme || parsed.refScheme == httpsScheme {
-			return SessionSourceMediumTerm{}, false
-		}
-		return SessionSourceMediumTerm{
-			Source: referralSource,
-			Medium: "referral",
-			Term:   "",
-		}, true
+		return SessionSourceMediumTerm{}, false
 	}
 	if parsed.refHostNoWWW == pageDomain {
 		return SessionSourceMediumTerm{}, false
 	}
 	return SessionSourceMediumTerm{
-		Source: referralSource,
+		Source: parsed.refHostNoWWW,
 		Medium: "referral",
 		Term:   "",
 	}, true

--- a/pkg/columns/sessioncolumns/session_smt_source.go
+++ b/pkg/columns/sessioncolumns/session_smt_source.go
@@ -179,14 +179,21 @@ func NewCompositeSourceMediumTermDetector(detectors ...SourceMediumTermDetector)
 
 const parsedURLsMetadataKey = "session_smt_parsed_urls"
 
+const (
+	httpScheme  = "http"
+	httpsScheme = "https"
+)
+
 type parsedURLs struct {
-	pageURL      *url.URL
-	pageQP       url.Values
-	refURL       *url.URL
-	refQP        url.Values
-	refHost      string
-	refHostNoWWW string
-	refRaw       string
+	pageURL            *url.URL
+	pageQP             url.Values
+	refURL             *url.URL
+	refQP              url.Values
+	refScheme          string
+	refHost            string
+	refHostNoWWW       string
+	refRaw             string
+	refMatchCandidates []string
 }
 
 func ensureParsedURLs(event *schema.Event) *parsedURLs {
@@ -229,12 +236,14 @@ func ensureParsedURLs(event *schema.Event) *parsedURLs {
 				result.refRaw = refRaw
 				result.refURL = parsed
 				result.refQP = parsed.Query()
+				result.refScheme = strings.ToLower(parsed.Scheme)
 				result.refHost = strings.ReplaceAll(
 					strings.ToLower(parsed.Hostname()),
 					" ",
 					"-",
 				)
 				result.refHostNoWWW = trimWWW(result.refHost)
+				result.refMatchCandidates = buildReferrerMatchCandidates(parsed, result.refHost, result.refHostNoWWW)
 			}
 		}
 	}
@@ -246,6 +255,69 @@ func ensureParsedURLs(event *schema.Event) *parsedURLs {
 func trimWWW(host string) string {
 	host = strings.ToLower(host)
 	return strings.TrimPrefix(host, "www.")
+}
+
+// Build referrer match candidates for Matomo-derived source lists, which expect
+// canonical hosts or package-like suffixes such as linkedin.android.
+func buildReferrerMatchCandidates(parsed *url.URL, refHost, refHostNoWWW string) []string {
+	candidates := make([]string, 0, 4)
+	appendCandidate := func(candidate string) {
+		candidate = strings.TrimSpace(strings.ToLower(candidate))
+		if candidate == "" {
+			return
+		}
+		for _, existing := range candidates {
+			if existing == candidate {
+				return
+			}
+		}
+		candidates = append(candidates, candidate)
+	}
+
+	appendCandidate(refHost)
+	appendCandidate(refHostNoWWW)
+
+	if parsed != nil && parsed.Scheme != "" && parsed.Scheme != httpScheme && parsed.Scheme != httpsScheme {
+		for _, candidate := range hostSuffixCandidates(refHostNoWWW) {
+			appendCandidate(candidate)
+		}
+	}
+
+	return candidates
+}
+
+func hostSuffixCandidates(host string) []string {
+	parts := strings.Split(host, ".")
+	if len(parts) < 2 {
+		return nil
+	}
+
+	result := make([]string, 0, len(parts)-1)
+	for idx := 1; idx < len(parts); idx++ {
+		candidate := strings.Join(parts[idx:], ".")
+		if candidate == "" {
+			continue
+		}
+		result = append(result, candidate)
+	}
+
+	return result
+}
+
+func fallbackReferralSource(parsed *parsedURLs) string {
+	if parsed == nil {
+		return ""
+	}
+	if parsed.refScheme == "" || parsed.refScheme == httpScheme || parsed.refScheme == httpsScheme {
+		return parsed.refHostNoWWW
+	}
+	for idx := len(parsed.refMatchCandidates) - 1; idx >= 0; idx-- {
+		candidate := parsed.refMatchCandidates[idx]
+		if candidate != parsed.refHostNoWWW {
+			return candidate
+		}
+	}
+	return parsed.refHostNoWWW
 }
 
 type directSourceMediumTermDetector struct {
@@ -313,17 +385,15 @@ type fromRefererSourceMediumTermDetector struct {
 
 func (d *fromRefererSourceMediumTermDetector) Detect(event *schema.Event) (SessionSourceMediumTerm, bool) {
 	parsedURLs := ensureParsedURLs(event)
-	if parsedURLs.refHost == "" {
+	if len(parsedURLs.refMatchCandidates) == 0 {
 		return SessionSourceMediumTerm{}, false
 	}
-	for _, condition := range d.conditions {
-		sourceMediumTerm, ok := condition(parsedURLs.refHost, parsedURLs.refQP)
-		if ok {
-			return sourceMediumTerm, true
-		}
-		sourceMediumTerm, ok = condition(parsedURLs.refHostNoWWW, parsedURLs.refQP)
-		if ok {
-			return sourceMediumTerm, true
+	for _, candidate := range parsedURLs.refMatchCandidates {
+		for _, condition := range d.conditions {
+			sourceMediumTerm, ok := condition(candidate, parsedURLs.refQP)
+			if ok {
+				return sourceMediumTerm, true
+			}
 		}
 	}
 	return SessionSourceMediumTerm{}, false
@@ -614,18 +684,36 @@ func (d *genericReferralSourceMediumTermDetector) Detect(event *schema.Event) (S
 	if parsed.refHostNoWWW == "" {
 		return SessionSourceMediumTerm{}, false
 	}
-	if parsed.pageURL == nil {
+	referralSource := fallbackReferralSource(parsed)
+	if referralSource == "" {
 		return SessionSourceMediumTerm{}, false
+	}
+	if parsed.pageURL == nil {
+		if parsed.refScheme == "" || parsed.refScheme == httpScheme || parsed.refScheme == httpsScheme {
+			return SessionSourceMediumTerm{}, false
+		}
+		return SessionSourceMediumTerm{
+			Source: referralSource,
+			Medium: "referral",
+			Term:   "",
+		}, true
 	}
 	pageDomain := trimWWW(parsed.pageURL.Hostname())
 	if pageDomain == "" {
-		return SessionSourceMediumTerm{}, false
+		if parsed.refScheme == "" || parsed.refScheme == httpScheme || parsed.refScheme == httpsScheme {
+			return SessionSourceMediumTerm{}, false
+		}
+		return SessionSourceMediumTerm{
+			Source: referralSource,
+			Medium: "referral",
+			Term:   "",
+		}, true
 	}
 	if parsed.refHostNoWWW == pageDomain {
 		return SessionSourceMediumTerm{}, false
 	}
 	return SessionSourceMediumTerm{
-		Source: parsed.refHostNoWWW,
+		Source: referralSource,
 		Medium: "referral",
 		Term:   "",
 	}, true

--- a/pkg/columns/sessioncolumns/session_smt_source.go
+++ b/pkg/columns/sessioncolumns/session_smt_source.go
@@ -29,6 +29,7 @@ var sessionSourceMediumTermDetector = NewCompositeSourceMediumTermDetector(
 	),
 	must(NewVideoSourceMediumTermDetector()),
 	must(NewEmailSourceMediumTermDetector()),
+	must(NewReferralSourceMediumTermDetector()),
 	NewMailRefererSourceMediumTermDetector(),
 	must(NewSocialsSourceMediumTermDetector()),
 	must(NewAISourceMediumTermDetector()),
@@ -98,6 +99,9 @@ var videoYAML []byte
 
 //go:embed smt/emails.yaml
 var emailsYAML []byte
+
+//go:embed smt/referrals.yaml
+var referralsYAML []byte
 
 // SourceMediumTermDetector is an interface for detecting the source, medium, and term of an event.
 type SourceMediumTermDetector interface {
@@ -569,6 +573,33 @@ func NewEmailSourceMediumTermDetector() (SourceMediumTermDetector, error) {
 					return SessionSourceMediumTerm{
 						Source: strings.ToLower(emailName),
 						Medium: "email",
+						Term:   "",
+					}
+				}),
+			)
+		}
+	}
+	return &fromRefererSourceMediumTermDetector{
+		conditions: conditions,
+	}, nil
+}
+
+// NewReferralSourceMediumTermDetector returns a new source medium term detector for referrals.yaml.
+func NewReferralSourceMediumTermDetector() (SourceMediumTermDetector, error) {
+	referrals := make(map[string][]string)
+	err := yaml.Unmarshal(referralsYAML, &referrals)
+	if err != nil {
+		return nil, err
+	}
+	conditions := []refererCondition{}
+	for referralName, urls := range referrals {
+		for _, urlPattern := range urls {
+			conditions = append(
+				conditions,
+				NewFromRefererExactMatchCondition(urlPattern, func(qp url.Values) SessionSourceMediumTerm {
+					return SessionSourceMediumTerm{
+						Source: strings.ToLower(referralName),
+						Medium: "referral",
 						Term:   "",
 					}
 				}),

--- a/pkg/columns/sessioncolumns/smt/ai.yaml
+++ b/pkg/columns/sessioncolumns/smt/ai.yaml
@@ -10,6 +10,7 @@ ChatGPT:
   - chatgpt.com
   - chat.openai.com
   - labs.openai.com
+  - com.openai.chatgpt
 
 Claude:
   - claude.ai
@@ -26,6 +27,7 @@ Deepseek:
 Gemini:
   - gemini.google.com
   - bard.google.com
+  - com.google.android.apps.bard
 
 Grok:
   - grok.com
@@ -48,6 +50,7 @@ NotebookLM:
 
 Perplexity:
   - perplexity.ai
+  - ai.perplexity.app.android
 
 Qwen:
   - chat.qwen.ai

--- a/pkg/columns/sessioncolumns/smt/emails.yaml
+++ b/pkg/columns/sessioncolumns/smt/emails.yaml
@@ -1,12 +1,14 @@
 Gmail:
   - gmail.com
   - mail.google.com
+  - com.google.android.gm
 
 Outlook:
   - outlook.com
   - hotmail.com
   - live.com
   - msn.com
+  - com.microsoft.office.outlook
 
 Yahoo Mail:
   - yahoo.com
@@ -110,4 +112,3 @@ Gmx:
 
 Rediff:
   - rediff.com
-

--- a/pkg/columns/sessioncolumns/smt/referrals.yaml
+++ b/pkg/columns/sessioncolumns/smt/referrals.yaml
@@ -1,0 +1,5 @@
+Chrome:
+  - com.android.chrome
+
+Firefox:
+  - org.mozilla.firefox

--- a/pkg/columns/sessioncolumns/smt/socials.yaml
+++ b/pkg/columns/sessioncolumns/smt/socials.yaml
@@ -54,6 +54,7 @@ Facebook:
   - fb.me
   - m.facebook.com
   - l.facebook.com
+  - com.facebook.katana
 
 Fetlife:
   - fetlife.com
@@ -100,6 +101,7 @@ identi.ca:
 Instagram:
   - instagram.com
   - l.instagram.com
+  - com.instagram.android
 
 lang-8:
   - lang-8.com
@@ -120,6 +122,7 @@ Last.fm:
 LinkedIn:
   - linkedin.com
   - lnkd.in
+  - com.linkedin.android
   - linkedin.android
 
 LiveJournal:
@@ -261,6 +264,7 @@ Pinterest:
   - pt.pinterest.com
   - ru.pinterest.com
   - se.pinterest.com
+  - com.pinterest
 
 Pixelfed:
   - pixelfed.social
@@ -288,6 +292,13 @@ Skyrock:
 
 Snapchat:
   - snapchat.com
+  - com.snapchat.android
+
+Slack:
+  - com.slack
+
+WhatsApp:
+  - com.whatsapp
 
 Sonico.com:
   - sonico.com
@@ -320,6 +331,7 @@ Threads:
 
 TikTok:
   - tiktok.com
+  - com.zhiliaoapp.musically
 
 Tuenti:
   - tuenti.com
@@ -335,6 +347,7 @@ Twitter:
   - twitter.com
   - t.co
   - x.com
+  - com.twitter.android
 
 Sourceforge:
   - sourceforge.net

--- a/pkg/columns/sessioncolumns/smt/video.yaml
+++ b/pkg/columns/sessioncolumns/smt/video.yaml
@@ -1,6 +1,7 @@
 YouTube:
   - youtube.com
   - youtu.be
+  - com.google.android.youtube
 
 Vimeo:
   - vimeo.com
@@ -10,6 +11,7 @@ Dailymotion:
 
 Twitch:
   - twitch.tv
+  - tv.twitch.android.app
 
 Rumble:
   - rumble.com
@@ -34,4 +36,3 @@ Chaturbate:
 
 ManyVids:
   - manyvids.com
-


### PR DESCRIPTION
## Summary
- build additional referrer match candidates for non-HTTP schemes so Matomo-derived source lists can match package-like android app referrers such as `linkedin.android`
- keep detector matching generic while falling back to stripped referral sources like `slack` for unmapped app referrers without page URL context
- add regression coverage for `android-app://com.slack/` session attribution