### PR TITLE
feat(receiver): expose ProxyTrust interface and WithProxyTrust option

### DIFF
--- a/pkg/receiver/ip.go
+++ b/pkg/receiver/ip.go
@@ -7,21 +7,24 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-// proxyTrust controls whether and which proxy-set headers are trusted
+// ProxyTrust controls whether and which proxy-set headers are trusted
 // when extracting the client's real IP address.
-type proxyTrust interface {
-	isTrustedProxy(ip net.IP) bool
+//
+// Implement this interface and pass it to WithProxyTrust to inject fully
+// custom proxy-trust logic.
+type ProxyTrust interface {
+	IsTrustedProxy(ip net.IP) bool
 }
 
 // noProxyTrust trusts no proxy — headers are always ignored.
 type noProxyTrust struct{}
 
-func (noProxyTrust) isTrustedProxy(net.IP) bool { return false }
+func (noProxyTrust) IsTrustedProxy(net.IP) bool { return false }
 
 // allProxyTrust trusts every proxy — headers are always honoured.
 type allProxyTrust struct{}
 
-func (allProxyTrust) isTrustedProxy(net.IP) bool { return true }
+func (allProxyTrust) IsTrustedProxy(net.IP) bool { return true }
 
 // cidrProxyTrust trusts only proxies whose remote address falls within
 // one of the configured CIDR ranges.
@@ -53,13 +56,23 @@ func newCIDRProxyTrust(cidrs []string) (*cidrProxyTrust, error) {
 	return &cidrProxyTrust{nets: nets}, nil
 }
 
-func (t *cidrProxyTrust) isTrustedProxy(ip net.IP) bool {
+func (t *cidrProxyTrust) IsTrustedProxy(ip net.IP) bool {
 	for _, n := range t.nets {
 		if n.Contains(ip) {
 			return true
 		}
 	}
 	return false
+}
+
+// WithProxyTrust configures the server to use a custom ProxyTrust
+// implementation for deciding which proxies are trusted. This is the escape
+// hatch for scenarios where neither WithTrustAllProxies nor
+// WithTrustedProxies fits (e.g. dynamic allow-lists, cloud-metadata lookups).
+func WithProxyTrust(trust ProxyTrust) ServerOption {
+	return func(s *Server) {
+		s.proxyTrust = trust
+	}
 }
 
 // WithTrustAllProxies configures the server to trust all proxies, honouring
@@ -103,7 +116,7 @@ func WithTrustedProxies(cidrs ...string) ServerOption {
 func (s *Server) realIP(ctx *fasthttp.RequestCtx) string {
 	remoteIP := ctx.RemoteIP()
 
-	if !s.proxyTrust.isTrustedProxy(remoteIP) {
+	if !s.proxyTrust.IsTrustedProxy(remoteIP) {
 		return remoteIP.String()
 	}
 

--- a/pkg/receiver/ip_test.go
+++ b/pkg/receiver/ip_test.go
@@ -430,6 +430,72 @@ func TestWithTrustedProxies_PanicsOnInvalidCIDR(t *testing.T) {
 	})
 }
 
+// customProxyTrust is a hand-written stub that trusts only one specific IP.
+type customProxyTrust struct {
+	trustedIP net.IP
+}
+
+func (c customProxyTrust) IsTrustedProxy(ip net.IP) bool {
+	return c.trustedIP.Equal(ip)
+}
+
+func TestWithProxyTrust_CustomImplementation(t *testing.T) {
+	// given — trust only 10.1.2.3
+	trust := customProxyTrust{trustedIP: net.ParseIP("10.1.2.3")}
+	s := NewServer(nil, nil, nil, nil, 0, WithProxyTrust(trust))
+
+	tests := []struct {
+		name       string
+		setup      func() *fasthttp.RequestCtx
+		expectedIP string
+	}{
+		{
+			name: "custom trusted proxy - header honoured",
+			setup: func() *fasthttp.RequestCtx {
+				ctx := &fasthttp.RequestCtx{}
+				ctx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP("10.1.2.3"), Port: 1})
+				ctx.Request.Header.Set("X-Real-IP", "203.0.113.7")
+				return ctx
+			},
+			expectedIP: "203.0.113.7",
+		},
+		{
+			name: "untrusted proxy - header ignored",
+			setup: func() *fasthttp.RequestCtx {
+				ctx := &fasthttp.RequestCtx{}
+				ctx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP("10.1.2.4"), Port: 1})
+				ctx.Request.Header.Set("X-Real-IP", "203.0.113.7")
+				return ctx
+			},
+			expectedIP: "10.1.2.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			ctx := tt.setup()
+
+			// when
+			ip := s.realIP(ctx)
+
+			// then
+			assert.Equal(t, tt.expectedIP, ip)
+		})
+	}
+}
+
+func TestNewServer_WithProxyTrust_StoresCustomImplementation(t *testing.T) {
+	// given
+	trust := customProxyTrust{trustedIP: net.ParseIP("1.2.3.4")}
+
+	// when
+	s := NewServer(nil, nil, nil, nil, 0, WithProxyTrust(trust))
+
+	// then
+	assert.Equal(t, trust, s.proxyTrust)
+}
+
 func TestNewServer_DefaultProxyTrust(t *testing.T) {
 	// given / when
 	s := NewServer(nil, nil, nil, nil, 0)

--- a/pkg/receiver/server.go
+++ b/pkg/receiver/server.go
@@ -119,7 +119,7 @@ type Server struct {
 	validationRules HitValidatingRule
 	host            string
 	port            int
-	proxyTrust      proxyTrust
+	proxyTrust      ProxyTrust
 	readTimeout     time.Duration
 	writeTimeout    time.Duration
 	maxConcurrency  int


### PR DESCRIPTION
## Summary

- Exports the internal `proxyTrust` interface as `ProxyTrust` (method renamed `IsTrustedProxy`) so external callers can implement custom proxy-trust logic.
- Adds `WithProxyTrust(ProxyTrust) ServerOption` as an escape hatch alongside the existing `WithTrustAllProxies` and `WithTrustedProxies` helpers.
- Updates all internal implementations (`noProxyTrust`, `allProxyTrust`, `cidrProxyTrust`) to satisfy the exported interface.
- Adds tests covering custom `ProxyTrust` injection via `WithProxyTrust`.