### PR TITLE
fix(session): remove warehouse driver caching in writer

### DIFF
--- a/pkg/sessions/writer.go
+++ b/pkg/sessions/writer.go
@@ -29,9 +29,7 @@ type sessionWriterImpl struct {
 	layoutsCache   *ristretto.Cache[string, schema.Layout]
 	layoutsLock    sync.Mutex
 
-	warehouseCache    *ristretto.Cache[string, warehouse.Driver]
 	warehouseRegistry warehouse.Registry
-	warehouseLock     sync.Mutex
 
 	columnsRegistry schema.ColumnsRegistry
 	columnsCache    *ristretto.Cache[string, schema.Columns]
@@ -120,14 +118,6 @@ func (m *sessionWriterImpl) getSchemaForWriting(propertyID, table string) (*arro
 		}
 	}
 	return nil, fmt.Errorf("table %s not found", table)
-}
-
-func (m *sessionWriterImpl) getWarehouse(propertyID string) (warehouse.Driver, error) {
-	driver, err := getCached(m.warehouseCache, &m.warehouseLock, m.warehouseRegistry.Get, propertyID, m.cacheTTL)
-	if err != nil {
-		return nil, err
-	}
-	return driver, nil
 }
 
 func (m *sessionWriterImpl) getColumns(propertyID string) (schema.Columns, error) {
@@ -219,7 +209,7 @@ func (m *sessionWriterImpl) prepareDeps(sessions []*schema.Session) (*writeDeps,
 
 	propertyID := sessions[0].PropertyID
 
-	driver, err := m.getWarehouse(propertyID)
+	driver, err := m.warehouseRegistry.Get(propertyID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get warehouse for property ID %s: %w", propertyID, err)
 	}
@@ -356,7 +346,6 @@ func NewSessionWriter(
 		writeTimeout:             30 * time.Second,
 		concurrency:              10,
 		warehouseRegistry:        whr,
-		warehouseCache:           createDefaultCache[warehouse.Driver](),
 		columnsRegistry:          columnsRegistry,
 		columnsCache:             createDefaultCache[schema.Columns](),
 		layoutRegistry:           layouts,

--- a/pkg/sessions/writer_test.go
+++ b/pkg/sessions/writer_test.go
@@ -3,6 +3,7 @@ package sessions
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,6 +13,33 @@ import (
 	"github.com/d8a-tech/d8a/pkg/warehouse"
 	"github.com/stretchr/testify/assert"
 )
+
+type countingWarehouseRegistry struct {
+	mu        sync.Mutex
+	driver    warehouse.Driver
+	getCalls  int
+	closeCall int
+}
+
+func (r *countingWarehouseRegistry) Get(_ string) (warehouse.Driver, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.getCalls++
+	return r.driver, nil
+}
+
+func (r *countingWarehouseRegistry) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.closeCall++
+	return nil
+}
+
+func (r *countingWarehouseRegistry) GetCallCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.getCalls
+}
 
 func newTestWriter(ctx context.Context, mockDriver warehouse.Driver) SessionWriter {
 	return NewSessionWriter(
@@ -162,4 +190,42 @@ func TestWriter_SplitterError_WritesUnsplitSession(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, mockDriver.WriteCalls, 1,
 		"session must be written even when splitter returns an error")
+}
+
+func TestWriter_ResolvesWarehousePerWriteCall(t *testing.T) {
+	// given
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	mockDriver := warehouse.NewMockWarehouseDriver()
+	registry := &countingWarehouseRegistry{driver: mockDriver}
+	writer := NewSessionWriter(
+		ctx,
+		registry,
+		schema.NewStaticColumnsRegistry(
+			map[string]schema.Columns{},
+			schema.NewColumns(
+				[]schema.SessionColumn{},
+				[]schema.EventColumn{},
+				[]schema.SessionScopedEventColumn{},
+			),
+		),
+		schema.NewStaticLayoutRegistry(
+			map[string]schema.Layout{},
+			schema.NewEmbeddedSessionColumnsLayout(
+				"events",
+				"session_",
+			),
+		),
+		splitter.NewStaticRegistry(splitter.NewNoop()),
+	)
+
+	// when
+	err1 := writer.Write(testSession("1", "1", "1"))
+	err2 := writer.Write(testSession("1", "2", "2"))
+
+	// then
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.Equal(t, 2, registry.GetCallCount())
+	assert.Len(t, mockDriver.WriteCalls, 2)
 }


### PR DESCRIPTION
## Summary
- remove `SessionWriter` warehouse driver caching and resolve the driver directly from the registry for each write call
- keep layout and columns caching intact, since those registries are still reused by property
- add a writer test that proves warehouse resolution now happens per `Write(...)` call

## Verification
- `go test ./pkg/sessions`
- `~/go/bin/golangci-lint run ./... -c .golangci.yml`