### PR TITLE
feat(properties): add metadata field to settings

### DIFF
--- a/pkg/properties/properties.go
+++ b/pkg/properties/properties.go
@@ -26,6 +26,7 @@ type Settings struct {
 
 	Filters       *FiltersConfig
 	CustomColumns []CustomColumnConfig
+	Metadata      map[string]any
 }
 
 // FiltersSafe returns the filters configuration, ensuring it is never nil.


### PR DESCRIPTION
## Summary
- add `Metadata map[string]any` to `properties.Settings`
- keep the field runtime-only in this repository with no YAML, CLI, or config loading changes
- leave existing behavior unchanged while allowing downstream code to attach extra property metadata