### PR TITLE
Add per-table ClickHouse DDL hints via Arrow schema metadata

### DIFF
--- a/pkg/warehouse/clickhouse/driver.go
+++ b/pkg/warehouse/clickhouse/driver.go
@@ -22,6 +22,7 @@ type clickhouseDriver struct {
 	prepareBatch      func(ctx context.Context, query string) (clickhouseWriteBatch, error)
 	database          string
 	queryMapper       warehouse.QueryMapper
+	chQueryMapper     *clickhouseQueryMapper
 	fieldTypeMapper   warehouse.FieldTypeMapper[SpecificClickhouseType]
 	queryTimeout      time.Duration
 	typeComparer      *warehouse.TypeComparer
@@ -44,11 +45,13 @@ func NewClickHouseTableDriver(
 		return nil, fmt.Errorf("opening ClickHouse connection: %w", err)
 	}
 
+	chqm := newClickHouseQueryMapper(opts...)
 	driver := &clickhouseDriver{
 		db:                db,
 		conn:              conn,
 		database:          database,
-		queryMapper:       NewClickHouseQueryMapper(opts...),
+		queryMapper:       chqm,
+		chQueryMapper:     chqm,
 		fieldTypeMapper:   NewFieldTypeMapper(),
 		queryTimeout:      30 * time.Second,
 		typeComparer:      warehouse.NewTypeComparer(),
@@ -65,7 +68,17 @@ func (d *clickhouseDriver) CreateTable(table string, schema *arrow.Schema) error
 	// Construct full table name with database (quoted for SQL, raw for errors)
 	fullTableName := quoteFullTableName(d.database, table)
 	rawTableName := fmt.Sprintf("%s.%s", d.database, table)
-	query, err := warehouse.CreateTableQuery(d.queryMapper, fullTableName, schema)
+
+	// Apply per-schema DDL hints if present, otherwise fall back to driver defaults.
+	mapper := warehouse.QueryMapper(d.chQueryMapper)
+	if orderBy := GetOrderBy(schema); orderBy != nil {
+		partitionBy := GetPartitionBy(schema)
+		mapper = d.chQueryMapper.withHints(orderBy, partitionBy)
+	} else if partitionBy := GetPartitionBy(schema); partitionBy != "" {
+		mapper = d.chQueryMapper.withHints(d.chQueryMapper.orderBy, partitionBy)
+	}
+
+	query, err := warehouse.CreateTableQuery(mapper, fullTableName, schema)
 	if err != nil {
 		return err
 	}

--- a/pkg/warehouse/clickhouse/driver.go
+++ b/pkg/warehouse/clickhouse/driver.go
@@ -21,8 +21,7 @@ type clickhouseDriver struct {
 	conn              clickhouse.Conn
 	prepareBatch      func(ctx context.Context, query string) (clickhouseWriteBatch, error)
 	database          string
-	queryMapper       warehouse.QueryMapper
-	chQueryMapper     *clickhouseQueryMapper
+	queryMapper       *clickhouseQueryMapper
 	fieldTypeMapper   warehouse.FieldTypeMapper[SpecificClickhouseType]
 	queryTimeout      time.Duration
 	typeComparer      *warehouse.TypeComparer
@@ -51,7 +50,6 @@ func NewClickHouseTableDriver(
 		conn:              conn,
 		database:          database,
 		queryMapper:       chqm,
-		chQueryMapper:     chqm,
 		fieldTypeMapper:   NewFieldTypeMapper(),
 		queryTimeout:      30 * time.Second,
 		typeComparer:      warehouse.NewTypeComparer(),
@@ -70,12 +68,12 @@ func (d *clickhouseDriver) CreateTable(table string, schema *arrow.Schema) error
 	rawTableName := fmt.Sprintf("%s.%s", d.database, table)
 
 	// Apply per-schema DDL hints if present, otherwise fall back to driver defaults.
-	mapper := warehouse.QueryMapper(d.chQueryMapper)
+	mapper := warehouse.QueryMapper(d.queryMapper)
 	if orderBy := GetOrderBy(schema); orderBy != nil {
 		partitionBy := GetPartitionBy(schema)
-		mapper = d.chQueryMapper.withHints(orderBy, partitionBy)
+		mapper = d.queryMapper.withHints(orderBy, partitionBy)
 	} else if partitionBy := GetPartitionBy(schema); partitionBy != "" {
-		mapper = d.chQueryMapper.withHints(d.chQueryMapper.orderBy, partitionBy)
+		mapper = d.queryMapper.withHints(d.queryMapper.orderBy, partitionBy)
 	}
 
 	query, err := warehouse.CreateTableQuery(mapper, fullTableName, schema)

--- a/pkg/warehouse/clickhouse/hints.go
+++ b/pkg/warehouse/clickhouse/hints.go
@@ -1,0 +1,98 @@
+package clickhouse
+
+import (
+	"strings"
+
+	"github.com/apache/arrow-go/v18/arrow"
+)
+
+// Metadata keys for per-table ClickHouse DDL hints stored in Arrow schema metadata.
+// These allow callers to override the driver-level ORDER BY and PARTITION BY defaults
+// on a per-schema basis without changing the warehouse.Driver interface.
+const (
+	// MetaOrderBy is the Arrow schema metadata key for a comma-separated list of
+	// ORDER BY columns for ClickHouse table creation.
+	// Example value: "toDate(timestamp), session_id"
+	MetaOrderBy = "d8a.warehouse.clickhouse.order_by"
+
+	// MetaPartitionBy is the Arrow schema metadata key for the PARTITION BY expression
+	// for ClickHouse table creation.
+	// Example value: "toYYYYMM(timestamp)"
+	MetaPartitionBy = "d8a.warehouse.clickhouse.partition_by"
+)
+
+// SetOrderBy returns a new *arrow.Schema with the ClickHouse ORDER BY hint set.
+// The columns are joined with ", " in the DDL; pass them individually.
+// Existing schema metadata is preserved.
+func SetOrderBy(schema *arrow.Schema, columns []string) *arrow.Schema {
+	return setMeta(schema, MetaOrderBy, strings.Join(columns, ","))
+}
+
+// SetPartitionBy returns a new *arrow.Schema with the ClickHouse PARTITION BY hint set.
+// Existing schema metadata is preserved.
+func SetPartitionBy(schema *arrow.Schema, expr string) *arrow.Schema {
+	return setMeta(schema, MetaPartitionBy, expr)
+}
+
+// GetOrderBy reads the ORDER BY columns from Arrow schema metadata.
+// Returns nil if the key is absent or the value is empty.
+func GetOrderBy(schema *arrow.Schema) []string {
+	val := schemaMetaValue(schema, MetaOrderBy)
+	if val == "" {
+		return nil
+	}
+	parts := strings.Split(val, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// GetPartitionBy reads the PARTITION BY expression from Arrow schema metadata.
+// Returns empty string if the key is absent.
+func GetPartitionBy(schema *arrow.Schema) string {
+	return schemaMetaValue(schema, MetaPartitionBy)
+}
+
+// setMeta returns a new schema with the given metadata key set.
+func setMeta(schema *arrow.Schema, key, value string) *arrow.Schema {
+	existing := schema.Metadata()
+	keys := existing.Keys()
+	vals := existing.Values()
+
+	// Replace existing key if present, otherwise append.
+	for i, k := range keys {
+		if k != key {
+			continue
+		}
+		newVals := make([]string, len(vals))
+		copy(newVals, vals)
+		newVals[i] = value
+		md := arrow.NewMetadata(keys, newVals)
+		return arrow.NewSchema(schema.Fields(), &md)
+	}
+
+	newKeys := make([]string, len(keys)+1)
+	copy(newKeys, keys)
+	newKeys[len(keys)] = key
+
+	newVals := make([]string, len(vals)+1)
+	copy(newVals, vals)
+	newVals[len(vals)] = value
+
+	md := arrow.NewMetadata(newKeys, newVals)
+	return arrow.NewSchema(schema.Fields(), &md)
+}
+
+// schemaMetaValue returns the value for a metadata key from the schema, or "".
+func schemaMetaValue(schema *arrow.Schema, key string) string {
+	md := schema.Metadata()
+	idx := md.FindKey(key)
+	if idx < 0 {
+		return ""
+	}
+	return md.Values()[idx]
+}

--- a/pkg/warehouse/clickhouse/hints_test.go
+++ b/pkg/warehouse/clickhouse/hints_test.go
@@ -1,0 +1,141 @@
+package clickhouse
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/d8a-tech/d8a/pkg/warehouse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetGetOrderBy(t *testing.T) {
+	// given
+	base := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+
+	// when
+	schema := SetOrderBy(base, []string{"col_a", "col_b"})
+	result := GetOrderBy(schema)
+
+	// then
+	assert.Equal(t, []string{"col_a", "col_b"}, result)
+}
+
+func TestSetGetPartitionBy(t *testing.T) {
+	// given
+	base := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+
+	// when
+	schema := SetPartitionBy(base, "toYYYYMM(ts)")
+	result := GetPartitionBy(schema)
+
+	// then
+	assert.Equal(t, "toYYYYMM(ts)", result)
+}
+
+func TestGetOrderBy_absent(t *testing.T) {
+	// given
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+
+	// when / then
+	assert.Nil(t, GetOrderBy(schema))
+}
+
+func TestGetPartitionBy_absent(t *testing.T) {
+	// given
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+
+	// when / then
+	assert.Empty(t, GetPartitionBy(schema))
+}
+
+func TestCreateTableQuery_schemaMetaOverridesOrderBy(t *testing.T) {
+	// given: driver mapper with default order_by
+	mapper := newClickHouseQueryMapper(
+		WithOrderBy([]string{"default_col"}),
+		WithPartitionBy("default_partition"),
+	)
+
+	base := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+	schema := SetOrderBy(base, []string{"col_a", "col_b"})
+
+	// when
+	overrideMapper := mapper.withHints(GetOrderBy(schema), GetPartitionBy(schema))
+	query, err := warehouse.CreateTableQuery(overrideMapper, "db.tbl", schema)
+
+	// then
+	require.NoError(t, err)
+	assert.Contains(t, query, "ORDER BY (col_a, col_b)")
+	// partition_by falls back to empty (not set in schema)
+	assert.NotContains(t, query, "PARTITION BY")
+}
+
+func TestCreateTableQuery_schemaMetaOverridesPartitionBy(t *testing.T) {
+	// given
+	mapper := newClickHouseQueryMapper(
+		WithOrderBy([]string{"default_col"}),
+		WithPartitionBy("default_partition"),
+	)
+
+	base := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+	schema := SetPartitionBy(base, "toYYYYMM(ts)")
+
+	// when: only partition_by is overridden; order_by keeps driver default
+	overrideMapper := mapper.withHints(mapper.orderBy, GetPartitionBy(schema))
+	query, err := warehouse.CreateTableQuery(overrideMapper, "db.tbl", schema)
+
+	// then
+	require.NoError(t, err)
+	assert.Contains(t, query, "PARTITION BY toYYYYMM(ts)")
+	assert.Contains(t, query, "ORDER BY (default_col)")
+}
+
+func TestCreateTableQuery_defaultsApplyWhenMetaAbsent(t *testing.T) {
+	// given
+	mapper := newClickHouseQueryMapper(
+		WithOrderBy([]string{"default_col"}),
+		WithPartitionBy("default_partition"),
+	)
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+
+	// when: no metadata → use mapper directly (no withHints)
+	query, err := warehouse.CreateTableQuery(mapper, "db.tbl", schema)
+
+	// then
+	require.NoError(t, err)
+	assert.Contains(t, query, "ORDER BY (default_col)")
+	assert.Contains(t, query, "PARTITION BY default_partition")
+}
+
+func TestCreateTableQuery_multipleOrderByColumns(t *testing.T) {
+	// given
+	mapper := newClickHouseQueryMapper()
+
+	base := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+	schema := SetOrderBy(base, []string{"toDate(ts)", "session_id", "event_id"})
+
+	// when
+	overrideMapper := mapper.withHints(GetOrderBy(schema), GetPartitionBy(schema))
+	query, err := warehouse.CreateTableQuery(overrideMapper, "db.tbl", schema)
+
+	// then
+	require.NoError(t, err)
+	assert.Contains(t, query, "ORDER BY (toDate(ts), session_id, event_id)")
+}

--- a/pkg/warehouse/clickhouse/qm.go
+++ b/pkg/warehouse/clickhouse/qm.go
@@ -19,6 +19,11 @@ type clickhouseQueryMapper struct {
 
 // NewClickHouseQueryMapper creates a new ClickHouse query mapper.
 func NewClickHouseQueryMapper(opts ...Options) warehouse.QueryMapper {
+	return newClickHouseQueryMapper(opts...)
+}
+
+// newClickHouseQueryMapper creates and returns the concrete *clickhouseQueryMapper.
+func newClickHouseQueryMapper(opts ...Options) *clickhouseQueryMapper {
 	q := &clickhouseQueryMapper{
 		engine:          "MergeTree()",
 		fieldTypeMapper: NewFieldTypeMapper(),
@@ -58,6 +63,14 @@ func WithIndexGranularity(granularity int) Options {
 	return func(q *clickhouseQueryMapper) {
 		q.indexGranularity = granularity
 	}
+}
+
+// withHints returns a shallow copy of the mapper with overridden orderBy and partitionBy.
+func (q *clickhouseQueryMapper) withHints(orderBy []string, partitionBy string) *clickhouseQueryMapper {
+	cp := *q
+	cp.orderBy = orderBy
+	cp.partitionBy = partitionBy
+	return &cp
 }
 
 func (q *clickhouseQueryMapper) TablePredicate(table string) string {


### PR DESCRIPTION
## Summary

- Adds `MetaOrderBy` and `MetaPartitionBy` Arrow schema metadata key constants in the ClickHouse warehouse package.
- Adds ergonomic helpers (`SetOrderBy`, `SetPartitionBy`, `GetOrderBy`, `GetPartitionBy`) to embed/read these hints on `*arrow.Schema`.
- Updates `CreateTable` to read per-schema metadata and apply it when building the `CREATE TABLE` suffix, falling back to driver-level defaults when absent.
- No `warehouse.Driver` or `QueryMapper` interface changes.

## Changes

| File | What |
|------|------|
| `pkg/warehouse/clickhouse/hints.go` | New: metadata key constants + schema helper functions |
| `pkg/warehouse/clickhouse/hints_test.go` | New: focused tests for helpers and DDL override behavior |
| `pkg/warehouse/clickhouse/qm.go` | Unexported `newClickHouseQueryMapper` constructor + `withHints` shallow-copy method |
| `pkg/warehouse/clickhouse/driver.go` | `CreateTable` reads schema metadata; stores `*clickhouseQueryMapper` alongside interface |

## Behavior

- Schema with `MetaOrderBy` / `MetaPartitionBy` → used in that table's `CREATE TABLE`.
- Schema without hints → existing driver defaults apply unchanged.
- Other driver operations (`Write`, `AddColumn`, `MissingColumns`) are unaffected.