### PR TITLE
Rename is_bounce column to page_is_bounce

### DIFF
--- a/pkg/columns/columntests/columns_page_view_sse_test.go
+++ b/pkg/columns/columntests/columns_page_view_sse_test.go
@@ -333,7 +333,7 @@ func TestPageViewSSECoreColumns(t *testing.T) {
 					require.NoError(t, closeErr)
 					result := make([]any, 0, len(whd.WriteCalls[0].Records))
 					for _, record := range whd.WriteCalls[0].Records {
-						result = append(result, record["is_bounce"])
+						result = append(result, record["page_is_bounce"])
 					}
 					assert.Equal(t, tc.expected, result)
 				}, proto)

--- a/pkg/columns/core.go
+++ b/pkg/columns/core.go
@@ -407,8 +407,8 @@ var CoreInterfaces = struct {
 		Field: &arrow.Field{Name: "session_is_exit_page", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	},
 	SSEIsBounce: schema.Interface{
-		ID:    "core.d8a.tech/events/is_bounce",
-		Field: &arrow.Field{Name: "is_bounce", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+		ID:    "core.d8a.tech/events/page_is_bounce",
+		Field: &arrow.Field{Name: "page_is_bounce", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
 	},
 	EventPreviousPageLocation: schema.Interface{
 		ID:    "core.d8a.tech/events/previous_page_location",


### PR DESCRIPTION
## Summary

- Renames the `SSEIsBounce` column ID from `core.d8a.tech/events/is_bounce` to `core.d8a.tech/events/page_is_bounce`
- Updates the Arrow field name from `is_bounce` to `page_is_bounce`
- Updates the corresponding test assertion to use the new field name