### PR TITLE
Add session-level client ID column

### DIFF
--- a/pkg/columns/core.go
+++ b/pkg/columns/core.go
@@ -82,7 +82,8 @@ var CoreInterfaces = struct {
 	SSETrafficFilterName      schema.Interface
 
 	// Session columns
-	SessionID schema.Interface
+	SessionID       schema.Interface
+	SessionClientID schema.Interface
 
 	SessionSource schema.Interface
 	SessionMedium schema.Interface
@@ -434,6 +435,10 @@ var CoreInterfaces = struct {
 	SessionID: schema.Interface{
 		ID:    "core.d8a.tech/sessions/id",
 		Field: &arrow.Field{Name: "session_id", Type: arrow.BinaryTypes.String},
+	},
+	SessionClientID: schema.Interface{
+		ID:    "core.d8a.tech/sessions/client_id",
+		Field: &arrow.Field{Name: "session_client_id", Type: arrow.BinaryTypes.String},
 	},
 	SessionSource: schema.Interface{
 		ID:    "core.d8a.tech/sessions/source",

--- a/pkg/columns/sessioncolumns/session_client_id.go
+++ b/pkg/columns/sessioncolumns/session_client_id.go
@@ -1,0 +1,27 @@
+package sessioncolumns
+
+import (
+	"github.com/d8a-tech/d8a/pkg/columns"
+	"github.com/d8a-tech/d8a/pkg/schema"
+)
+
+// SessionClientIDColumn is the column for the client ID of a session
+var SessionClientIDColumn = columns.NewSimpleSessionColumn(
+	columns.CoreInterfaces.SessionClientID.ID,
+	columns.CoreInterfaces.SessionClientID.Field,
+	func(session *schema.Session) (any, schema.D8AColumnWriteError) {
+		if len(session.Events) == 0 {
+			return nil, schema.NewBrokenSessionError("session has no events")
+		}
+		return string(session.Events[0].BoundHit.ClientID), nil
+	},
+	columns.WithSessionColumnDocs(
+		"Session Client ID",
+		"The client ID of the first event in the session, used for session-level reporting.",
+	),
+	columns.WithSessionColumnDependsOn(
+		schema.DependsOnEntry{
+			Interface: columns.CoreInterfaces.EventClientID.ID,
+		},
+	),
+)

--- a/pkg/columns/sessioncolumns/session_client_id_test.go
+++ b/pkg/columns/sessioncolumns/session_client_id_test.go
@@ -1,0 +1,76 @@
+package sessioncolumns
+
+import (
+	"testing"
+
+	"github.com/d8a-tech/d8a/pkg/columns"
+	"github.com/d8a-tech/d8a/pkg/hits"
+	"github.com/d8a-tech/d8a/pkg/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSessionClientIDColumn_Write(t *testing.T) {
+	tests := []struct {
+		name             string
+		session          *schema.Session
+		expectedClientID string
+		expectedError    string
+		expectedPanic    bool
+	}{
+		{
+			name: "normal session writes first event client ID",
+			session: &schema.Session{
+				Events: []*schema.Event{
+					{BoundHit: &hits.Hit{ClientID: hits.ClientID("first-client-id")}},
+					{BoundHit: &hits.Hit{ClientID: hits.ClientID("second-client-id")}},
+				},
+				Values: map[string]any{},
+			},
+			expectedClientID: "first-client-id",
+		},
+		{
+			name: "empty session returns broken session error",
+			session: &schema.Session{
+				Events: []*schema.Event{},
+				Values: map[string]any{},
+			},
+			expectedError: "session has no events",
+		},
+		{
+			name: "missing BoundHit panics consistently with nearby columns",
+			session: &schema.Session{
+				Events: []*schema.Event{{BoundHit: nil}},
+				Values: map[string]any{},
+			},
+			expectedPanic: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			session := tt.session
+
+			if tt.expectedPanic {
+				// when / then
+				assert.Panics(t, func() {
+					_ = SessionClientIDColumn.Write(session)
+				})
+				return
+			}
+
+			// when
+			err := SessionClientIDColumn.Write(session)
+
+			// then
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
+				assert.IsType(t, &schema.BrokenSessionError{}, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedClientID, session.Values[columns.CoreInterfaces.SessionClientID.Field.Name])
+		})
+	}
+}

--- a/pkg/columnset/columnset.go
+++ b/pkg/columnset/columnset.go
@@ -143,6 +143,7 @@ func eventColumns(psr properties.SettingsRegistry) []schema.EventColumn {
 func sessionColumns() []schema.SessionColumn {
 	return []schema.SessionColumn{
 		sessioncolumns.SessionIDColumn,
+		sessioncolumns.SessionClientIDColumn,
 		sessioncolumns.FirstEventTimeColumn,
 		sessioncolumns.LastEventTimeColumn,
 		sessioncolumns.DurationColumn,


### PR DESCRIPTION
## Summary
- add the core `session_client_id` interface and a session column that uses the first event's `BoundHit.ClientID`
- register the new session column in the standard session column set
- cover normal, broken-session, and missing-`BoundHit` behavior with session-column tests

## Verification
- go test ./pkg/columns/sessioncolumns ./pkg/columnset
- ~/go/bin/golangci-lint run ./pkg/columns/sessioncolumns/... ./pkg/columnset/... -c .golangci.yml
- go test ./...
- ~/go/bin/golangci-lint run ./... -c .golangci.yml