### PR TITLE
Fix session client ID column nullability

### DIFF
--- a/pkg/columns/core.go
+++ b/pkg/columns/core.go
@@ -438,7 +438,7 @@ var CoreInterfaces = struct {
 	},
 	SessionClientID: schema.Interface{
 		ID:    "core.d8a.tech/sessions/client_id",
-		Field: &arrow.Field{Name: "session_client_id", Type: arrow.BinaryTypes.String},
+		Field: &arrow.Field{Name: "session_client_id", Type: arrow.BinaryTypes.String, Nullable: true},
 	},
 	SessionSource: schema.Interface{
 		ID:    "core.d8a.tech/sessions/source",

--- a/pkg/columns/sessioncolumns/session_client_id_test.go
+++ b/pkg/columns/sessioncolumns/session_client_id_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestSessionClientIDColumn_Write(t *testing.T) {
+	assert.True(t, SessionClientIDColumn.Implements().Field.Nullable)
+
 	tests := []struct {
 		name             string
 		session          *schema.Session


### PR DESCRIPTION
## Summary
- mark the `session_client_id` core interface field as nullable so warehouse schemas match optional session column behavior
- add a regression assertion covering the session client ID column's nullable schema
- verify the change with targeted tests and repo lint