### PR TITLE
Add property-level IP masking

### DIFF
--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -356,6 +356,19 @@ var propertySettingsSplitByMaxEventsFlag *cli.IntFlag = &cli.IntFlag{
 	Value:   1000,
 }
 
+var propertySettingsIPMaskingLevelFlag *cli.IntFlag = &cli.IntFlag{
+	Name: "property-settings-ip-masking-level",
+	Usage: "Property setting property.settings.ip_masking_level. Controls privacy masking for client IP addresses. " +
+		"0: disabled. " +
+		"1: IPv4 /24, IPv6 /48. " +
+		"2: IPv4 /16, IPv6 /32. " +
+		"3: IPv4 /8, IPv6 /16. " +
+		"4: IPv4 /0, IPv6 /0. " +
+		"Session-stamp joining must be disabled when this level is non-zero.", //nolint:lll // it's a description
+	Sources: defaultSourceChain("PROPERTY_SETTINGS_IP_MASKING_LEVEL", "property.settings.ip_masking_level"),
+	Value:   0,
+}
+
 var historicalExcludedURLParams = []string{
 	"utm_marketing_tactic",
 	"utm_source_platform",
@@ -707,6 +720,7 @@ func getServerFlags() []cli.Flag {
 			propertyNameFlag,
 			propertySettingsSplitByUserIDFlag,
 			propertySettingsSplitByCampaignFlag,
+			propertySettingsIPMaskingLevelFlag,
 			protocolFlag,
 			matomoTrackingEndpointsFlag,
 			ga4ParamsFlag,

--- a/pkg/cmd/property_settings_test.go
+++ b/pkg/cmd/property_settings_test.go
@@ -22,20 +22,74 @@ func newPropertySettingsFlagsForConfigTests() []cli.Flag {
 		&cli.StringFlag{Name: protocolFlag.Name, Value: ""},
 		&cli.StringFlag{Name: propertyIDFlag.Name, Value: ""},
 		&cli.StringFlag{Name: propertyNameFlag.Name, Value: ""},
-		&cli.BoolFlag{Name: propertySettingsSplitByUserIDFlag.Name, Sources: defaultSourceChain("PROPERTY_SETTINGS_SPLIT_BY_USER_ID", "property.settings.split_by_user_id"), Value: true},
-		&cli.BoolFlag{Name: propertySettingsSplitByCampaignFlag.Name, Sources: defaultSourceChain("PROPERTY_SETTINGS_SPLIT_BY_CAMPAIGN", "property.settings.split_by_campaign"), Value: true},
-		&cli.DurationFlag{Name: propertySettingsSplitByTimeSinceFirstEventFlag.Name, Sources: defaultSourceChain("PROPERTY_SETTINGS_SPLIT_BY_TIME_SINCE_FIRST_EVENT", "property.settings.split_by_time_since_first_event"), Value: 12 * time.Hour},
-		&cli.IntFlag{Name: propertySettingsSplitByMaxEventsFlag.Name, Sources: defaultSourceChain("PROPERTY_SETTINGS_SPLIT_BY_MAX_EVENTS", "property.settings.split_by_max_events"), Value: 1000},
-		&cli.StringSliceFlag{Name: propertySettingsExcludedURLParamsFlag.Name, Sources: defaultSourceChain("PROPERTY_SETTINGS_EXCLUDED_URL_PARAMS", "property.settings.excluded_url_params"), Value: historicalExcludedURLParams},
-		&cli.DurationFlag{Name: sessionsTimeoutFlag.Name, Sources: defaultSourceChain("SESSIONS_TIMEOUT", "sessions.timeout"), Value: 30 * time.Minute},
-		&cli.BoolFlag{Name: sessionsJoinBySessionStampFlag.Name, Sources: defaultSourceChain("SESSIONS_JOIN_BY_SESSION_STAMP", "sessions.join_by_session_stamp"), Value: true},
-		&cli.BoolFlag{Name: sessionsJoinByUserIDFlag.Name, Sources: defaultSourceChain("SESSIONS_JOIN_BY_USER_ID", "sessions.join_by_user_id"), Value: true},
-		&cli.IntFlag{Name: propertySettingsIPMaskingLevelFlag.Name, Sources: defaultSourceChain("PROPERTY_SETTINGS_IP_MASKING_LEVEL", "property.settings.ip_masking_level"), Value: 0},
-		&cli.StringSliceFlag{Name: filtersFieldsFlag.Name, Sources: defaultSourceChain("FILTERS_FIELDS", "filters.fields")},
-		&cli.StringSliceFlag{Name: filtersConditionsFlag.Name, Sources: defaultSourceChain("FILTERS_CONDITIONS", "filters.conditions")},
-		&cli.StringFlag{Name: ga4ParamsFlag.Name, Sources: ga4ParamsFlag.Sources},
-		&cli.StringFlag{Name: matomoCustomDimensionsFlag.Name, Sources: matomoCustomDimensionsFlag.Sources},
-		&cli.StringFlag{Name: matomoCustomVariablesFlag.Name, Sources: matomoCustomVariablesFlag.Sources},
+		&cli.BoolFlag{
+			Name:    propertySettingsSplitByUserIDFlag.Name,
+			Sources: defaultSourceChain("PROPERTY_SETTINGS_SPLIT_BY_USER_ID", "property.settings.split_by_user_id"),
+			Value:   true,
+		},
+		&cli.BoolFlag{
+			Name:    propertySettingsSplitByCampaignFlag.Name,
+			Sources: defaultSourceChain("PROPERTY_SETTINGS_SPLIT_BY_CAMPAIGN", "property.settings.split_by_campaign"),
+			Value:   true,
+		},
+		&cli.DurationFlag{
+			Name: propertySettingsSplitByTimeSinceFirstEventFlag.Name,
+			Sources: defaultSourceChain(
+				"PROPERTY_SETTINGS_SPLIT_BY_TIME_SINCE_FIRST_EVENT",
+				"property.settings.split_by_time_since_first_event",
+			),
+			Value: 12 * time.Hour,
+		},
+		&cli.IntFlag{
+			Name:    propertySettingsSplitByMaxEventsFlag.Name,
+			Sources: defaultSourceChain("PROPERTY_SETTINGS_SPLIT_BY_MAX_EVENTS", "property.settings.split_by_max_events"),
+			Value:   1000,
+		},
+		&cli.StringSliceFlag{
+			Name:    propertySettingsExcludedURLParamsFlag.Name,
+			Sources: defaultSourceChain("PROPERTY_SETTINGS_EXCLUDED_URL_PARAMS", "property.settings.excluded_url_params"),
+			Value:   historicalExcludedURLParams,
+		},
+		&cli.DurationFlag{
+			Name:    sessionsTimeoutFlag.Name,
+			Sources: defaultSourceChain("SESSIONS_TIMEOUT", "sessions.timeout"),
+			Value:   30 * time.Minute,
+		},
+		&cli.BoolFlag{
+			Name:    sessionsJoinBySessionStampFlag.Name,
+			Sources: defaultSourceChain("SESSIONS_JOIN_BY_SESSION_STAMP", "sessions.join_by_session_stamp"),
+			Value:   true,
+		},
+		&cli.BoolFlag{
+			Name:    sessionsJoinByUserIDFlag.Name,
+			Sources: defaultSourceChain("SESSIONS_JOIN_BY_USER_ID", "sessions.join_by_user_id"),
+			Value:   true,
+		},
+		&cli.IntFlag{
+			Name:    propertySettingsIPMaskingLevelFlag.Name,
+			Sources: defaultSourceChain("PROPERTY_SETTINGS_IP_MASKING_LEVEL", "property.settings.ip_masking_level"),
+			Value:   0,
+		},
+		&cli.StringSliceFlag{
+			Name:    filtersFieldsFlag.Name,
+			Sources: defaultSourceChain("FILTERS_FIELDS", "filters.fields"),
+		},
+		&cli.StringSliceFlag{
+			Name:    filtersConditionsFlag.Name,
+			Sources: defaultSourceChain("FILTERS_CONDITIONS", "filters.conditions"),
+		},
+		&cli.StringFlag{
+			Name:    ga4ParamsFlag.Name,
+			Sources: ga4ParamsFlag.Sources,
+		},
+		&cli.StringFlag{
+			Name:    matomoCustomDimensionsFlag.Name,
+			Sources: matomoCustomDimensionsFlag.Sources,
+		},
+		&cli.StringFlag{
+			Name:    matomoCustomVariablesFlag.Name,
+			Sources: matomoCustomVariablesFlag.Sources,
+		},
 	}
 }
 

--- a/pkg/cmd/property_settings_test.go
+++ b/pkg/cmd/property_settings_test.go
@@ -25,11 +25,61 @@ func TestPropertySettings_DefaultExcludedURLParams(t *testing.T) {
 
 			// then
 			assert.Equal(t, historicalExcludedURLParams, settings.ExcludedURLParamsSafe())
+			assert.Equal(t, 0, settings.IPMaskingLevel)
 			return nil
 		},
 	}
 
 	require.NoError(t, app.Run(context.Background(), args))
+}
+
+func TestPropertySettings_OverrideIPMaskingLevelFromCLI(t *testing.T) {
+	// given
+	setDeliveryModeForTest(t, "")
+	args := []string{
+		"d8a-test",
+		"--property-settings-ip-masking-level=3",
+		"--sessions-join-by-session-stamp=false",
+	}
+	setCurrentRunArgsForTest(t, args)
+
+	app := &cli.Command{
+		Name:  "d8a-test",
+		Flags: mergeFlags([]cli.Flag{configFlag}, getServerFlags()),
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			// when
+			settings, err := propertySettings(cmd).GetByPropertyID(cmd.String(propertyIDFlag.Name))
+			require.NoError(t, err)
+
+			// then
+			assert.Equal(t, 3, settings.IPMaskingLevel)
+			return nil
+		},
+	}
+
+	require.NoError(t, app.Run(context.Background(), args))
+}
+
+func TestPropertySettings_OverrideIPMaskingLevelFromConfig(t *testing.T) {
+	// given
+	setDeliveryModeForTest(t, "")
+	configPath := writeConfigFile(t, `
+property:
+  settings:
+    ip_masking_level: 2
+`)
+	setConfigFileForTest(t, configPath)
+
+	// when
+	source := defaultSourceChain(
+		"PROPERTY_SETTINGS_IP_MASKING_LEVEL",
+		"property.settings.ip_masking_level",
+	)
+	value, found := source.Lookup()
+
+	// then
+	assert.True(t, found)
+	assert.Equal(t, "2", value)
 }
 
 func TestPropertySettings_OverrideExcludedURLParams(t *testing.T) {

--- a/pkg/cmd/property_settings_test.go
+++ b/pkg/cmd/property_settings_test.go
@@ -33,6 +33,37 @@ func TestPropertySettings_DefaultExcludedURLParams(t *testing.T) {
 	require.NoError(t, app.Run(context.Background(), args))
 }
 
+func TestPropertySettings_OverrideIPMaskingLevelFromConfig(t *testing.T) {
+	// given
+	setDeliveryModeForTest(t, "")
+	configPath := writeConfigFile(t, `
+property:
+  settings:
+    ip_masking_level: 2
+sessions:
+  join_by_session_stamp: false
+`)
+	setConfigFileForTest(t, configPath)
+	args := []string{"d8a-test", "--config=" + configPath}
+	setCurrentRunArgsForTest(t, args)
+
+	app := &cli.Command{
+		Name:  "d8a-test",
+		Flags: mergeFlags([]cli.Flag{configFlag}, getServerFlags()),
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			// when
+			settings, err := propertySettings(cmd).GetByPropertyID(cmd.String(propertyIDFlag.Name))
+			require.NoError(t, err)
+
+			// then
+			assert.Equal(t, 2, settings.IPMaskingLevel)
+			return nil
+		},
+	}
+
+	require.NoError(t, app.Run(context.Background(), args))
+}
+
 func TestPropertySettings_OverrideIPMaskingLevelFromCLI(t *testing.T) {
 	// given
 	setDeliveryModeForTest(t, "")
@@ -53,56 +84,6 @@ func TestPropertySettings_OverrideIPMaskingLevelFromCLI(t *testing.T) {
 
 			// then
 			assert.Equal(t, 3, settings.IPMaskingLevel)
-			return nil
-		},
-	}
-
-	require.NoError(t, app.Run(context.Background(), args))
-}
-
-func TestPropertySettings_OverrideIPMaskingLevelFromConfig(t *testing.T) {
-	// given
-	setDeliveryModeForTest(t, "")
-	configPath := writeConfigFile(t, `
-property:
-  settings:
-    ip_masking_level: 2
-sessions:
-  join_by_session_stamp: false
-`)
-	setConfigFileForTest(t, configPath)
-	args := []string{"d8a-test", "--config=" + configPath}
-	setCurrentRunArgsForTest(t, args)
-
-	app := &cli.Command{
-		Name:  "d8a-test",
-		Flags: mergeFlags([]cli.Flag{configFlag}, getServerFlags()),
-		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-			ipMaskingLevelSource := defaultSourceChain(
-				"PROPERTY_SETTINGS_IP_MASKING_LEVEL",
-				"property.settings.ip_masking_level",
-			)
-			ipMaskingLevel, found := ipMaskingLevelSource.Lookup()
-			require.True(t, found)
-			require.NoError(t, cmd.Set(propertySettingsIPMaskingLevelFlag.Name, ipMaskingLevel))
-
-			sessionStampJoinSource := defaultSourceChain(
-				"SESSIONS_JOIN_BY_SESSION_STAMP",
-				"sessions.join_by_session_stamp",
-			)
-			sessionStampJoin, found := sessionStampJoinSource.Lookup()
-			require.True(t, found)
-			require.NoError(t, cmd.Set(sessionsJoinBySessionStampFlag.Name, sessionStampJoin))
-
-			return ctx, nil
-		},
-		Action: func(_ context.Context, cmd *cli.Command) error {
-			// when
-			settings, err := propertySettings(cmd).GetByPropertyID(cmd.String(propertyIDFlag.Name))
-			require.NoError(t, err)
-
-			// then
-			assert.Equal(t, 2, settings.IPMaskingLevel)
 			return nil
 		},
 	}

--- a/pkg/cmd/property_settings_test.go
+++ b/pkg/cmd/property_settings_test.go
@@ -3,11 +3,41 @@ package cmd
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v3"
 )
+
+func newPropertySettingsFlagsForConfigTests() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:        configFlag.Name,
+			Aliases:     append([]string(nil), configFlag.Aliases...),
+			Value:       configFlag.Value,
+			Usage:       configFlag.Usage,
+			Destination: &configFile,
+		},
+		&cli.StringFlag{Name: protocolFlag.Name, Value: ""},
+		&cli.StringFlag{Name: propertyIDFlag.Name, Value: ""},
+		&cli.StringFlag{Name: propertyNameFlag.Name, Value: ""},
+		&cli.BoolFlag{Name: propertySettingsSplitByUserIDFlag.Name, Sources: defaultSourceChain("PROPERTY_SETTINGS_SPLIT_BY_USER_ID", "property.settings.split_by_user_id"), Value: true},
+		&cli.BoolFlag{Name: propertySettingsSplitByCampaignFlag.Name, Sources: defaultSourceChain("PROPERTY_SETTINGS_SPLIT_BY_CAMPAIGN", "property.settings.split_by_campaign"), Value: true},
+		&cli.DurationFlag{Name: propertySettingsSplitByTimeSinceFirstEventFlag.Name, Sources: defaultSourceChain("PROPERTY_SETTINGS_SPLIT_BY_TIME_SINCE_FIRST_EVENT", "property.settings.split_by_time_since_first_event"), Value: 12 * time.Hour},
+		&cli.IntFlag{Name: propertySettingsSplitByMaxEventsFlag.Name, Sources: defaultSourceChain("PROPERTY_SETTINGS_SPLIT_BY_MAX_EVENTS", "property.settings.split_by_max_events"), Value: 1000},
+		&cli.StringSliceFlag{Name: propertySettingsExcludedURLParamsFlag.Name, Sources: defaultSourceChain("PROPERTY_SETTINGS_EXCLUDED_URL_PARAMS", "property.settings.excluded_url_params"), Value: historicalExcludedURLParams},
+		&cli.DurationFlag{Name: sessionsTimeoutFlag.Name, Sources: defaultSourceChain("SESSIONS_TIMEOUT", "sessions.timeout"), Value: 30 * time.Minute},
+		&cli.BoolFlag{Name: sessionsJoinBySessionStampFlag.Name, Sources: defaultSourceChain("SESSIONS_JOIN_BY_SESSION_STAMP", "sessions.join_by_session_stamp"), Value: true},
+		&cli.BoolFlag{Name: sessionsJoinByUserIDFlag.Name, Sources: defaultSourceChain("SESSIONS_JOIN_BY_USER_ID", "sessions.join_by_user_id"), Value: true},
+		&cli.IntFlag{Name: propertySettingsIPMaskingLevelFlag.Name, Sources: defaultSourceChain("PROPERTY_SETTINGS_IP_MASKING_LEVEL", "property.settings.ip_masking_level"), Value: 0},
+		&cli.StringSliceFlag{Name: filtersFieldsFlag.Name, Sources: defaultSourceChain("FILTERS_FIELDS", "filters.fields")},
+		&cli.StringSliceFlag{Name: filtersConditionsFlag.Name, Sources: defaultSourceChain("FILTERS_CONDITIONS", "filters.conditions")},
+		&cli.StringFlag{Name: ga4ParamsFlag.Name, Sources: ga4ParamsFlag.Sources},
+		&cli.StringFlag{Name: matomoCustomDimensionsFlag.Name, Sources: matomoCustomDimensionsFlag.Sources},
+		&cli.StringFlag{Name: matomoCustomVariablesFlag.Name, Sources: matomoCustomVariablesFlag.Sources},
+	}
+}
 
 func TestPropertySettings_DefaultExcludedURLParams(t *testing.T) {
 	// given
@@ -89,6 +119,64 @@ func TestPropertySettings_OverrideIPMaskingLevelFromCLI(t *testing.T) {
 	}
 
 	require.NoError(t, app.Run(context.Background(), args))
+}
+
+func TestPropertySettings_InvalidIPMaskingLevelFromConfigPanics(t *testing.T) {
+	// given
+	setDeliveryModeForTest(t, "")
+	configPath := writeConfigFile(t, `
+property:
+  settings:
+    ip_masking_level: 5
+sessions:
+  join_by_session_stamp: false
+`)
+	setConfigFileForTest(t, configPath)
+	args := []string{"d8a-test", "--config=" + configPath}
+	setCurrentRunArgsForTest(t, args)
+
+	app := &cli.Command{
+		Name:  "d8a-test",
+		Flags: newPropertySettingsFlagsForConfigTests(),
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			_, _ = propertySettings(cmd).GetByPropertyID(cmd.String(propertyIDFlag.Name))
+			return nil
+		},
+	}
+
+	// then
+	assert.Panics(t, func() {
+		require.NoError(t, app.Run(context.Background(), args))
+	})
+}
+
+func TestPropertySettings_IPMaskingSessionStampConflictFromConfigPanics(t *testing.T) {
+	// given
+	setDeliveryModeForTest(t, "")
+	configPath := writeConfigFile(t, `
+property:
+  settings:
+    ip_masking_level: 1
+sessions:
+  join_by_session_stamp: true
+`)
+	setConfigFileForTest(t, configPath)
+	args := []string{"d8a-test", "--config=" + configPath}
+	setCurrentRunArgsForTest(t, args)
+
+	app := &cli.Command{
+		Name:  "d8a-test",
+		Flags: newPropertySettingsFlagsForConfigTests(),
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			_, _ = propertySettings(cmd).GetByPropertyID(cmd.String(propertyIDFlag.Name))
+			return nil
+		},
+	}
+
+	// then
+	assert.Panics(t, func() {
+		require.NoError(t, app.Run(context.Background(), args))
+	})
 }
 
 func TestPropertySettings_OverrideExcludedURLParams(t *testing.T) {

--- a/pkg/cmd/property_settings_test.go
+++ b/pkg/cmd/property_settings_test.go
@@ -67,19 +67,47 @@ func TestPropertySettings_OverrideIPMaskingLevelFromConfig(t *testing.T) {
 property:
   settings:
     ip_masking_level: 2
+sessions:
+  join_by_session_stamp: false
 `)
 	setConfigFileForTest(t, configPath)
+	args := []string{"d8a-test", "--config=" + configPath}
+	setCurrentRunArgsForTest(t, args)
 
-	// when
-	source := defaultSourceChain(
-		"PROPERTY_SETTINGS_IP_MASKING_LEVEL",
-		"property.settings.ip_masking_level",
-	)
-	value, found := source.Lookup()
+	app := &cli.Command{
+		Name:  "d8a-test",
+		Flags: mergeFlags([]cli.Flag{configFlag}, getServerFlags()),
+		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+			ipMaskingLevelSource := defaultSourceChain(
+				"PROPERTY_SETTINGS_IP_MASKING_LEVEL",
+				"property.settings.ip_masking_level",
+			)
+			ipMaskingLevel, found := ipMaskingLevelSource.Lookup()
+			require.True(t, found)
+			require.NoError(t, cmd.Set(propertySettingsIPMaskingLevelFlag.Name, ipMaskingLevel))
 
-	// then
-	assert.True(t, found)
-	assert.Equal(t, "2", value)
+			sessionStampJoinSource := defaultSourceChain(
+				"SESSIONS_JOIN_BY_SESSION_STAMP",
+				"sessions.join_by_session_stamp",
+			)
+			sessionStampJoin, found := sessionStampJoinSource.Lookup()
+			require.True(t, found)
+			require.NoError(t, cmd.Set(sessionsJoinBySessionStampFlag.Name, sessionStampJoin))
+
+			return ctx, nil
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			// when
+			settings, err := propertySettings(cmd).GetByPropertyID(cmd.String(propertyIDFlag.Name))
+			require.NoError(t, err)
+
+			// then
+			assert.Equal(t, 2, settings.IPMaskingLevel)
+			return nil
+		},
+	}
+
+	require.NoError(t, app.Run(context.Background(), args))
 }
 
 func TestPropertySettings_OverrideExcludedURLParams(t *testing.T) {

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -495,58 +495,64 @@ func buildReceiverServer(cmd *cli.Command, storage receiver.Storage, converter c
 }
 
 func propertySettings(cmd *cli.Command) properties.SettingsRegistry {
+	settings := &properties.Settings{
+		ProtocolID:                 cmd.String(protocolFlag.Name),
+		PropertyID:                 cmd.String(propertyIDFlag.Name),
+		PropertyName:               cmd.String(propertyNameFlag.Name),
+		PropertyMeasurementID:      "-",
+		SplitByUserID:              cmd.Bool(propertySettingsSplitByUserIDFlag.Name),
+		SplitByCampaign:            cmd.Bool(propertySettingsSplitByCampaignFlag.Name),
+		SplitByTimeSinceFirstEvent: cmd.Duration(propertySettingsSplitByTimeSinceFirstEventFlag.Name),
+		SplitByMaxEvents:           cmd.Int(propertySettingsSplitByMaxEventsFlag.Name),
+		ExcludedURLParams:          cmd.StringSlice(propertySettingsExcludedURLParamsFlag.Name),
+		SessionTimeout:             cmd.Duration(sessionsTimeoutFlag.Name),
+		SessionJoinBySessionStamp:  cmd.Bool(sessionsJoinBySessionStampFlag.Name),
+		SessionJoinByUserID:        cmd.Bool(sessionsJoinByUserIDFlag.Name),
+		IPMaskingLevel:             cmd.Int(propertySettingsIPMaskingLevelFlag.Name),
+		Filters: func() *properties.FiltersConfig {
+			var filtersConfig properties.FiltersConfig
+			// Config file is optional; stat before parsing
+			if _, err := os.Stat(configFile); err == nil {
+				var parseErr error
+				filtersConfig, parseErr = properties.ParseFilterConfig(configFile)
+				if parseErr != nil {
+					logrus.Panicf("failed to parse filters config: %v", parseErr)
+				}
+			}
+			// Override fields from YAML with flag value (flag takes precedence)
+			filtersConfig.Fields = cmd.StringSlice(filtersFieldsFlag.Name)
+
+			// Parse and append JSON-encoded conditions from flag/env
+			flagConditions := cmd.StringSlice(filtersConditionsFlag.Name)
+			for _, conditionJSON := range flagConditions {
+				var condition properties.ConditionConfig
+				if err := json.Unmarshal([]byte(conditionJSON), &condition); err != nil {
+					logrus.Warnf("skipping invalid JSON condition %q: %v", conditionJSON, err)
+					continue
+				}
+				filtersConfig.Conditions = append(filtersConfig.Conditions, condition)
+			}
+
+			return &filtersConfig
+		}(),
+		CustomColumns: func() []properties.CustomColumnConfig {
+			customColumns, loadErr := loadProtocolCustomColumns(cmd)
+			if loadErr != nil {
+				logrus.Panicf("failed to load protocol custom columns config: %v", loadErr)
+			}
+
+			return customColumns
+		}(),
+	}
+
+	if err := properties.ValidateSettings(settings); err != nil {
+		logrus.Panicf("invalid property settings: %v", err)
+	}
+
 	return properties.NewStaticSettingsRegistry(
 		[]properties.Settings{},
 		properties.WithDefaultConfig(
-			&properties.Settings{
-				ProtocolID:                 cmd.String(protocolFlag.Name),
-				PropertyID:                 cmd.String(propertyIDFlag.Name),
-				PropertyName:               cmd.String(propertyNameFlag.Name),
-				PropertyMeasurementID:      "-",
-				SplitByUserID:              cmd.Bool(propertySettingsSplitByUserIDFlag.Name),
-				SplitByCampaign:            cmd.Bool(propertySettingsSplitByCampaignFlag.Name),
-				SplitByTimeSinceFirstEvent: cmd.Duration(propertySettingsSplitByTimeSinceFirstEventFlag.Name),
-				SplitByMaxEvents:           cmd.Int(propertySettingsSplitByMaxEventsFlag.Name),
-				ExcludedURLParams:          cmd.StringSlice(propertySettingsExcludedURLParamsFlag.Name),
-
-				SessionTimeout:            cmd.Duration(sessionsTimeoutFlag.Name),
-				SessionJoinBySessionStamp: cmd.Bool(sessionsJoinBySessionStampFlag.Name),
-				SessionJoinByUserID:       cmd.Bool(sessionsJoinByUserIDFlag.Name),
-				Filters: func() *properties.FiltersConfig {
-					var filtersConfig properties.FiltersConfig
-					// Config file is optional; stat before parsing
-					if _, err := os.Stat(configFile); err == nil {
-						var parseErr error
-						filtersConfig, parseErr = properties.ParseFilterConfig(configFile)
-						if parseErr != nil {
-							logrus.Panicf("failed to parse filters config: %v", parseErr)
-						}
-					}
-					// Override fields from YAML with flag value (flag takes precedence)
-					filtersConfig.Fields = cmd.StringSlice(filtersFieldsFlag.Name)
-
-					// Parse and append JSON-encoded conditions from flag/env
-					flagConditions := cmd.StringSlice(filtersConditionsFlag.Name)
-					for _, conditionJSON := range flagConditions {
-						var condition properties.ConditionConfig
-						if err := json.Unmarshal([]byte(conditionJSON), &condition); err != nil {
-							logrus.Warnf("skipping invalid JSON condition %q: %v", conditionJSON, err)
-							continue
-						}
-						filtersConfig.Conditions = append(filtersConfig.Conditions, condition)
-					}
-
-					return &filtersConfig
-				}(),
-				CustomColumns: func() []properties.CustomColumnConfig {
-					customColumns, loadErr := loadProtocolCustomColumns(cmd)
-					if loadErr != nil {
-						logrus.Panicf("failed to load protocol custom columns config: %v", loadErr)
-					}
-
-					return customColumns
-				}(),
-			},
+			settings,
 		),
 	)
 }

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -480,16 +480,19 @@ func buildReceiverServer(cmd *cli.Command, storage receiver.Storage, converter c
 		logrus.Panicf("protocol %s not found", cmd.String(protocolFlag.Name))
 	}
 
+	settingsRegistry := propertySettings(cmd)
+
 	return receiver.NewServer(
 		storage,
 		receiver.NewNoopRawLogStorage(),
 		receiver.HitValidatingRuleSet(
 			1024*util.SafeIntToUint32(cmd.Int(receiverMaxHitKbytesFlag.Name)),
-			propertySettings(cmd),
+			settingsRegistry,
 		),
 		[]protocol.Protocol{currentProtocol},
 		cmd.Int(serverPortFlag.Name),
 		receiver.WithHost(cmd.String(serverHostFlag.Name)),
+		receiver.WithHitProcessingRule(receiver.IPMasking(settingsRegistry)),
 		trustedProxiesOption(cmd.StringSlice(serverTrustedProxiesFlag.Name)),
 	)
 }

--- a/pkg/dbip/columns_test.go
+++ b/pkg/dbip/columns_test.go
@@ -1,18 +1,33 @@
 package dbip_test
 
 import (
+	"net/netip"
 	"testing"
 
+	"github.com/d8a-tech/d8a/pkg/columns"
 	"github.com/d8a-tech/d8a/pkg/columns/columntests"
 	"github.com/d8a-tech/d8a/pkg/columnset"
 	"github.com/d8a-tech/d8a/pkg/currency"
 	"github.com/d8a-tech/d8a/pkg/dbip"
+	"github.com/d8a-tech/d8a/pkg/hits"
 	"github.com/d8a-tech/d8a/pkg/properties"
 	"github.com/d8a-tech/d8a/pkg/protocol/ga4"
+	"github.com/d8a-tech/d8a/pkg/schema"
 	"github.com/d8a-tech/d8a/pkg/warehouse"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type recordingLookupProvider struct {
+	lookupIP netip.Addr
+	result   *dbip.LookupResult
+	err      error
+}
+
+func (p *recordingLookupProvider) Lookup(ip netip.Addr) (*dbip.LookupResult, error) {
+	p.lookupIP = ip
+	return p.result, p.err
+}
 
 func TestDBIPColumns(t *testing.T) {
 	th1 := columntests.TestHitOne()
@@ -70,4 +85,25 @@ func TestDBIPColumns_WhenUnavailable_WritesNulls(t *testing.T) {
 			),
 		),
 	)
+}
+
+func TestDBIPColumns_UsesMaskedIPAlreadyPresentOnHit(t *testing.T) {
+	// given
+	provider := &recordingLookupProvider{
+		result: &dbip.LookupResult{City: "Masked City"},
+	}
+	factory, err := dbip.NewGeoColumnFactory(provider, dbip.CacheConfig{MaxEntries: 10})
+	require.NoError(t, err)
+
+	hit := hits.New()
+	hit.Request.IP = "192.168.1.0"
+	event := schema.NewEvent(hit)
+
+	// when
+	writeErr := dbip.CityColumn(factory).Write(event)
+
+	// then
+	require.NoError(t, writeErr)
+	assert.Equal(t, netip.MustParseAddr("192.168.1.0"), provider.lookupIP)
+	assert.Equal(t, "Masked City", event.Values[columns.CoreInterfaces.GeoCity.Field.Name])
 }

--- a/pkg/properties/properties.go
+++ b/pkg/properties/properties.go
@@ -23,6 +23,7 @@ type Settings struct {
 	SessionTimeout            time.Duration
 	SessionJoinBySessionStamp bool
 	SessionJoinByUserID       bool
+	IPMaskingLevel            int
 
 	Filters           *FiltersConfig
 	CustomColumns     []CustomColumnConfig

--- a/pkg/properties/testutils.go
+++ b/pkg/properties/testutils.go
@@ -19,6 +19,13 @@ func WithExcludedURLParams(params []string) TestSettingsOption {
 	}
 }
 
+// WithIPMaskingLevel sets the IP masking level for test settings.
+func WithIPMaskingLevel(level int) TestSettingsOption {
+	return func(s *Settings) {
+		s.IPMaskingLevel = level
+	}
+}
+
 // NewTestSettingRegistry is a test property source that returns a static property configuration.
 func NewTestSettingRegistry(opts ...TestSettingsOption) SettingsRegistry {
 	settings := &Settings{
@@ -29,6 +36,7 @@ func NewTestSettingRegistry(opts ...TestSettingsOption) SettingsRegistry {
 
 		SessionJoinBySessionStamp: true,
 		SessionJoinByUserID:       true,
+		IPMaskingLevel:            0,
 	}
 	for _, opt := range opts {
 		opt(settings)

--- a/pkg/properties/validation.go
+++ b/pkg/properties/validation.go
@@ -1,0 +1,20 @@
+package properties
+
+import "fmt"
+
+// ValidateSettings validates property settings.
+func ValidateSettings(settings *Settings) error {
+	if settings == nil {
+		return fmt.Errorf("settings must not be nil")
+	}
+
+	if settings.IPMaskingLevel < 0 || settings.IPMaskingLevel > 4 {
+		return fmt.Errorf("ip masking level must be between 0 and 4: %d", settings.IPMaskingLevel)
+	}
+
+	if settings.IPMaskingLevel > 0 && settings.SessionJoinBySessionStamp {
+		return fmt.Errorf("session join by session stamp must be disabled when ip masking level is non-zero")
+	}
+
+	return nil
+}

--- a/pkg/properties/validation_test.go
+++ b/pkg/properties/validation_test.go
@@ -1,0 +1,73 @@
+package properties
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSettings(t *testing.T) {
+	testCases := []struct {
+		name     string
+		settings *Settings
+		wantErr  string
+	}{
+		{
+			name:     "valid level 0",
+			settings: &Settings{IPMaskingLevel: 0},
+		},
+		{
+			name:     "valid level 1",
+			settings: &Settings{IPMaskingLevel: 1},
+		},
+		{
+			name:     "valid level 2",
+			settings: &Settings{IPMaskingLevel: 2},
+		},
+		{
+			name:     "valid level 3",
+			settings: &Settings{IPMaskingLevel: 3},
+		},
+		{
+			name:     "valid level 4",
+			settings: &Settings{IPMaskingLevel: 4},
+		},
+		{
+			name:     "invalid negative level",
+			settings: &Settings{IPMaskingLevel: -1},
+			wantErr:  "ip masking level must be between 0 and 4: -1",
+		},
+		{
+			name:     "invalid large level",
+			settings: &Settings{IPMaskingLevel: 5},
+			wantErr:  "ip masking level must be between 0 and 4: 5",
+		},
+		{
+			name: "masking conflicts with session stamp join",
+			settings: &Settings{
+				IPMaskingLevel:            1,
+				SessionJoinBySessionStamp: true,
+			},
+			wantErr: "session join by session stamp must be disabled when ip masking level is non-zero",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// given
+
+			// when
+			err := ValidateSettings(testCase.settings)
+
+			// then
+			if testCase.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Equal(t, testCase.wantErr, err.Error())
+		})
+	}
+}

--- a/pkg/receiver/ip_masking.go
+++ b/pkg/receiver/ip_masking.go
@@ -1,0 +1,56 @@
+package receiver
+
+import (
+	"net/netip"
+
+	"github.com/d8a-tech/d8a/pkg/hits"
+	"github.com/d8a-tech/d8a/pkg/properties"
+	"github.com/d8a-tech/d8a/pkg/protocol"
+)
+
+func maskIPByPrivacyLevel(ip string, level int) string {
+	if level == 0 {
+		return ip
+	}
+
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return ip
+	}
+
+	v4BitsByLevel := map[int]int{1: 24, 2: 16, 3: 8, 4: 0}
+	v6BitsByLevel := map[int]int{1: 48, 2: 32, 3: 16, 4: 0}
+
+	bits, ok := func() (int, bool) {
+		if addr.Is4() {
+			bits, ok := v4BitsByLevel[level]
+			return bits, ok
+		}
+
+		bits, ok := v6BitsByLevel[level]
+		return bits, ok
+	}()
+	if !ok {
+		return ip
+	}
+
+	return netip.PrefixFrom(addr, bits).Masked().Addr().String()
+}
+
+// IPMasking returns a hit processing rule that masks hit IPs per property settings.
+func IPMasking(settings properties.SettingsRegistry) HitProcessingRule {
+	return NewSimpleHitProcessingRule(func(_ protocol.Protocol, hit *hits.Hit) error {
+		propertySettings, err := settings.GetByPropertyID(hit.PropertyID)
+		if err != nil {
+			return err
+		}
+
+		if err := properties.ValidateSettings(propertySettings); err != nil {
+			return err
+		}
+
+		hit.MustParsedRequest().IP = maskIPByPrivacyLevel(hit.MustParsedRequest().IP, propertySettings.IPMaskingLevel)
+
+		return nil
+	})
+}

--- a/pkg/receiver/ip_test.go
+++ b/pkg/receiver/ip_test.go
@@ -511,3 +511,51 @@ func TestNewServer_WithTrustAllProxies(t *testing.T) {
 	// then
 	assert.IsType(t, allProxyTrust{}, s.proxyTrust)
 }
+
+func TestMaskIPByPrivacyLevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip       string
+		level    int
+		expected string
+	}{
+		{name: "ipv4 level 0", ip: "192.168.100.123", level: 0, expected: "192.168.100.123"},
+		{name: "ipv4 level 1", ip: "192.168.100.123", level: 1, expected: "192.168.100.0"},
+		{name: "ipv4 level 2", ip: "192.168.100.123", level: 2, expected: "192.168.0.0"},
+		{name: "ipv4 level 3", ip: "192.168.100.123", level: 3, expected: "192.0.0.0"},
+		{name: "ipv4 level 4", ip: "192.168.100.123", level: 4, expected: "0.0.0.0"},
+		{
+			name:     "ipv6 level 0",
+			ip:       "1050:5678:9012:3456:789a:bcde:f012:3456",
+			level:    0,
+			expected: "1050:5678:9012:3456:789a:bcde:f012:3456",
+		},
+		{name: "ipv6 level 1", ip: "1050:5678:9012:3456:789a:bcde:f012:3456", level: 1, expected: "1050:5678:9012::"},
+		{name: "ipv6 level 2", ip: "1050:5678:9012:3456:789a:bcde:f012:3456", level: 2, expected: "1050:5678::"},
+		{name: "ipv6 level 3", ip: "1050:5678:9012:3456:789a:bcde:f012:3456", level: 3, expected: "1050::"},
+		{name: "ipv6 level 4", ip: "1050:5678:9012:3456:789a:bcde:f012:3456", level: 4, expected: "::"},
+		{name: "invalid ip unchanged", ip: "not-an-ip", level: 2, expected: "not-an-ip"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, maskIPByPrivacyLevel(tt.ip, tt.level))
+		})
+	}
+}
+
+func TestRealIP_TrustedProxyThenMasking(t *testing.T) {
+	// given
+	s := trustedCIDRServer(t, "10.0.0.0/24")
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP("10.0.0.5"), Port: 1})
+	ctx.Request.Header.Set("X-Real-IP", "203.0.113.99")
+
+	// when
+	ip := s.realIP(ctx)
+	maskedIP := maskIPByPrivacyLevel(ip, 1)
+
+	// then
+	assert.Equal(t, "203.0.113.99", ip)
+	assert.Equal(t, "203.0.113.0", maskedIP)
+}

--- a/pkg/receiver/process.go
+++ b/pkg/receiver/process.go
@@ -1,0 +1,54 @@
+package receiver
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/d8a-tech/d8a/pkg/hits"
+	"github.com/d8a-tech/d8a/pkg/protocol"
+)
+
+// HitProcessingRule defines the interface for processing hits.
+type HitProcessingRule interface {
+	Process(p protocol.Protocol, hit *hits.Hit) error
+}
+
+type multipleHitProcessingRule struct {
+	rules []HitProcessingRule
+}
+
+func (r *multipleHitProcessingRule) Process(p protocol.Protocol, hit *hits.Hit) error {
+	var errs []error
+	for _, rule := range r.rules {
+		if err := rule.Process(p, hit); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("multiple hit processing rules failed: %w", errors.Join(errs...))
+	}
+	return nil
+}
+
+// NewMultipleHitProcessingRule creates a new processing rule that combines multiple rules.
+func NewMultipleHitProcessingRule(rules ...HitProcessingRule) HitProcessingRule {
+	return &multipleHitProcessingRule{rules: rules}
+}
+
+type simpleHitProcessingRule struct {
+	rule func(protocol.Protocol, *hits.Hit) error
+}
+
+func (r *simpleHitProcessingRule) Process(p protocol.Protocol, hit *hits.Hit) error {
+	return r.rule(p, hit)
+}
+
+// NewSimpleHitProcessingRule creates a new processing rule from a simple function.
+func NewSimpleHitProcessingRule(rule func(protocol.Protocol, *hits.Hit) error) HitProcessingRule {
+	return &simpleHitProcessingRule{rule: rule}
+}
+
+// NoopHitProcessingRule does not change hits.
+var NoopHitProcessingRule = NewSimpleHitProcessingRule(func(protocol.Protocol, *hits.Hit) error {
+	return nil
+})

--- a/pkg/receiver/server.go
+++ b/pkg/receiver/server.go
@@ -113,16 +113,17 @@ const (
 
 // Server holds all server-related dependencies and configuration
 type Server struct {
-	protocols       []protocol.Protocol
-	storage         Storage
-	rawLogStorage   RawLogStorage
-	validationRules HitValidatingRule
-	host            string
-	port            int
-	proxyTrust      ProxyTrust
-	readTimeout     time.Duration
-	writeTimeout    time.Duration
-	maxConcurrency  int
+	protocols          []protocol.Protocol
+	storage            Storage
+	rawLogStorage      RawLogStorage
+	hitProcessingRules HitProcessingRule
+	validationRules    HitValidatingRule
+	host               string
+	port               int
+	proxyTrust         ProxyTrust
+	readTimeout        time.Duration
+	writeTimeout       time.Duration
+	maxConcurrency     int
 }
 
 func WithHost(host string) ServerOption {
@@ -155,6 +156,12 @@ func WithMaxConcurrency(n int) ServerOption {
 	}
 }
 
+func WithHitProcessingRule(rule HitProcessingRule) ServerOption {
+	return func(s *Server) {
+		s.hitProcessingRules = rule
+	}
+}
+
 type ServerOption func(*Server)
 
 // NewServer creates a new Server instance with the provided dependencies
@@ -167,16 +174,17 @@ func NewServer(
 	opts ...ServerOption,
 ) *Server {
 	s := &Server{
-		protocols:       protocols,
-		storage:         storage,
-		rawLogStorage:   rawLogStorage,
-		validationRules: validationRules,
-		host:            "0.0.0.0",
-		port:            port,
-		proxyTrust:      noProxyTrust{},
-		readTimeout:     defaultReadTimeout,
-		writeTimeout:    defaultWriteTimeout,
-		maxConcurrency:  defaultMaxConcurrency,
+		protocols:          protocols,
+		storage:            storage,
+		rawLogStorage:      rawLogStorage,
+		hitProcessingRules: NoopHitProcessingRule,
+		validationRules:    validationRules,
+		host:               "0.0.0.0",
+		port:               port,
+		proxyTrust:         noProxyTrust{},
+		readTimeout:        defaultReadTimeout,
+		writeTimeout:       defaultWriteTimeout,
+		maxConcurrency:     defaultMaxConcurrency,
 	}
 
 	for _, opt := range opts {
@@ -259,19 +267,27 @@ func (s *Server) createHits(ctx *fasthttp.RequestCtx, p protocol.Protocol) ([]*h
 		Body:               bodyCopy,
 	}
 
-	if err := s.rawLogStorage.Store(request); err != nil {
-		logrus.Errorf("failed to store raw log: %v", err)
-	}
-
 	hits, err := p.Hits(ctx, request)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, hit := range hits {
+		if err := s.hitProcessingRules.Process(p, hit); err != nil {
+			return nil, err
+		}
 		if err := s.validationRules.Validate(p, hit); err != nil {
 			return nil, err
 		}
+	}
+
+	rawLogRequest := request
+	if len(hits) > 0 {
+		rawLogRequest = hits[0].Request
+	}
+
+	if err := s.rawLogStorage.Store(rawLogRequest); err != nil {
+		logrus.Errorf("failed to store raw log: %v", err)
 	}
 
 	return hits, nil

--- a/pkg/receiver/server_test.go
+++ b/pkg/receiver/server_test.go
@@ -29,6 +29,7 @@ type mockProtocol struct {
 	id      string
 	columns schema.Columns
 	err     error
+	hits    []*hits.Hit
 }
 
 func (m *mockProtocol) ID() string {
@@ -49,6 +50,13 @@ func (m *mockProtocol) Endpoints() []protocol.ProtocolEndpoint {
 }
 
 func (m *mockProtocol) Hits(_ *fasthttp.RequestCtx, request *hits.ParsedRequest) ([]*hits.Hit, error) {
+	if m.hits != nil {
+		for _, hit := range m.hits {
+			hit.Request = request.Clone()
+		}
+		return m.hits, m.err
+	}
+
 	theHit := hits.New()
 
 	theHit.ClientID = hits.ClientID("test_client_id")
@@ -61,6 +69,37 @@ func (m *mockProtocol) Hits(_ *fasthttp.RequestCtx, request *hits.ParsedRequest)
 
 func (m *mockProtocol) Columns() schema.Columns {
 	return m.columns
+}
+
+type capturingRawLogStorage struct {
+	requests []*hits.ParsedRequest
+}
+
+func (c *capturingRawLogStorage) Store(request *hits.ParsedRequest) error {
+	c.requests = append(c.requests, request.Clone())
+	return nil
+}
+
+type settingsRegistryStub struct {
+	settingsByPropertyID map[string]*properties.Settings
+	err                  error
+}
+
+func (s settingsRegistryStub) GetByMeasurementID(string) (*properties.Settings, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s settingsRegistryStub) GetByPropertyID(propertyID string) (*properties.Settings, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+
+	settings, ok := s.settingsByPropertyID[propertyID]
+	if !ok {
+		return nil, fmt.Errorf("unknown property ID: %s", propertyID)
+	}
+
+	return settings, nil
 }
 
 func TestHandleRequest(t *testing.T) {
@@ -262,4 +301,213 @@ func TestHandleRequest_ValidationErrorDoesNotLeakDetails(t *testing.T) {
 	assert.NotContains(t, body, "test_protocol")
 	assert.NotContains(t, body, "wrong_protocol")
 	assert.NotContains(t, body, "does not match")
+}
+
+func TestHandleRequest_MasksIPBeforeStorageAndRawLog(t *testing.T) {
+	// given
+	storage := &mockStorage{}
+	rawLogStorage := &capturingRawLogStorage{}
+	settingsRegistry := settingsRegistryStub{
+		settingsByPropertyID: map[string]*properties.Settings{
+			"test_property_id": {
+				PropertyID:     "test_property_id",
+				ProtocolID:     "test_protocol",
+				IPMaskingLevel: 1,
+			},
+		},
+	}
+	p := &mockProtocol{id: "test_protocol"}
+	server := NewServer(
+		storage,
+		rawLogStorage,
+		HitValidatingRuleSet(1024*128, settingsRegistry),
+		[]protocol.Protocol{p},
+		8080,
+		WithTrustAllProxies(),
+		WithHitProcessingRule(IPMasking(settingsRegistry)),
+	)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetHost("example.com")
+	ctx.Request.Header.SetHost("example.com")
+	ctx.Request.Header.Set("X-Real-IP", "192.168.1.123")
+	ctx.URI().SetPath("/collect")
+
+	// when
+	server.handleRequest(context.Background(), ctx, p)
+
+	// then
+	assert.Equal(t, fasthttp.StatusNoContent, ctx.Response.StatusCode())
+	assert.Len(t, storage.hits, 1)
+	assert.Equal(t, "192.168.1.0", storage.hits[0].MustParsedRequest().IP)
+	assert.Len(t, rawLogStorage.requests, 1)
+	assert.Equal(t, "192.168.1.0", rawLogStorage.requests[0].IP)
+}
+
+func TestHandleRequest_IPMaskingRegistryErrorReturnsBadRequest(t *testing.T) {
+	// given
+	storage := &mockStorage{}
+	settingsRegistry := settingsRegistryStub{err: fmt.Errorf("registry unavailable")}
+	p := &mockProtocol{id: "test_protocol"}
+	server := NewServer(
+		storage,
+		NewDummyRawLogStorage(),
+		HitValidatingRuleSet(1024*128, properties.NewStaticSettingsRegistry([]properties.Settings{{
+			PropertyID: "test_property_id",
+			ProtocolID: "test_protocol",
+		}})),
+		[]protocol.Protocol{p},
+		8080,
+		WithTrustAllProxies(),
+		WithHitProcessingRule(IPMasking(settingsRegistry)),
+	)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetHost("example.com")
+	ctx.Request.Header.SetHost("example.com")
+	ctx.Request.Header.Set("X-Real-IP", "192.168.1.123")
+	ctx.URI().SetPath("/collect")
+
+	// when
+	server.handleRequest(context.Background(), ctx, p)
+
+	// then
+	assert.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode())
+	assert.Empty(t, storage.hits)
+	assert.Contains(t, string(ctx.Response.Body()), "Bad Request")
+}
+
+func TestHandleRequest_StoresRawLogOnceAfterAllHitsValidate(t *testing.T) {
+	// given
+	storage := &mockStorage{}
+	rawLogStorage := &capturingRawLogStorage{}
+	settingsRegistry := settingsRegistryStub{
+		settingsByPropertyID: map[string]*properties.Settings{
+			"test_property_id": {
+				PropertyID:     "test_property_id",
+				ProtocolID:     "test_protocol",
+				IPMaskingLevel: 1,
+			},
+		},
+	}
+	hitOne := hits.New()
+	hitOne.PropertyID = "test_property_id"
+	hitOne.ClientID = "one"
+	hitOne.AuthoritativeClientID = hitOne.ClientID
+	hitOne.EventName = "page_view"
+	hitTwo := hits.New()
+	hitTwo.PropertyID = "test_property_id"
+	hitTwo.ClientID = "two"
+	hitTwo.AuthoritativeClientID = hitTwo.ClientID
+	hitTwo.EventName = "page_view"
+	p := &mockProtocol{id: "test_protocol", hits: []*hits.Hit{hitOne, hitTwo}}
+	server := NewServer(
+		storage,
+		rawLogStorage,
+		HitValidatingRuleSet(1024*128, settingsRegistry),
+		[]protocol.Protocol{p},
+		8080,
+		WithTrustAllProxies(),
+		WithHitProcessingRule(IPMasking(settingsRegistry)),
+	)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetHost("example.com")
+	ctx.Request.Header.SetHost("example.com")
+	ctx.Request.Header.Set("X-Real-IP", "192.168.1.123")
+	ctx.URI().SetPath("/collect")
+
+	// when
+	server.handleRequest(context.Background(), ctx, p)
+
+	// then
+	assert.Equal(t, fasthttp.StatusNoContent, ctx.Response.StatusCode())
+	assert.Len(t, storage.hits, 2)
+	assert.Len(t, rawLogStorage.requests, 1)
+	assert.Equal(t, "192.168.1.0", rawLogStorage.requests[0].IP)
+}
+
+func TestHandleRequest_DoesNotStoreRawLogWhenLaterHitValidationFails(t *testing.T) {
+	// given
+	storage := &mockStorage{}
+	rawLogStorage := &capturingRawLogStorage{}
+	settingsRegistry := settingsRegistryStub{
+		settingsByPropertyID: map[string]*properties.Settings{
+			"test_property_id": {
+				PropertyID: "test_property_id",
+				ProtocolID: "test_protocol",
+			},
+			"bad_property_id": {
+				PropertyID: "bad_property_id",
+				ProtocolID: "different_protocol",
+			},
+		},
+	}
+	hitOne := hits.New()
+	hitOne.PropertyID = "test_property_id"
+	hitOne.ClientID = "one"
+	hitOne.AuthoritativeClientID = hitOne.ClientID
+	hitOne.EventName = "page_view"
+	hitTwo := hits.New()
+	hitTwo.PropertyID = "bad_property_id"
+	hitTwo.ClientID = "two"
+	hitTwo.AuthoritativeClientID = hitTwo.ClientID
+	hitTwo.EventName = "page_view"
+	p := &mockProtocol{id: "test_protocol", hits: []*hits.Hit{hitOne, hitTwo}}
+	server := NewServer(
+		storage,
+		rawLogStorage,
+		HitValidatingRuleSet(1024*128, settingsRegistry),
+		[]protocol.Protocol{p},
+		8080,
+		WithTrustAllProxies(),
+		WithHitProcessingRule(IPMasking(settingsRegistry)),
+	)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetHost("example.com")
+	ctx.Request.Header.SetHost("example.com")
+	ctx.Request.Header.Set("X-Real-IP", "192.168.1.123")
+	ctx.URI().SetPath("/collect")
+
+	// when
+	server.handleRequest(context.Background(), ctx, p)
+
+	// then
+	assert.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode())
+	assert.Empty(t, storage.hits)
+	assert.Empty(t, rawLogStorage.requests)
+}
+
+func TestHandleRequest_StoresRawLogOnceForSuccessfulZeroHitRequest(t *testing.T) {
+	// given
+	storage := &mockStorage{}
+	rawLogStorage := &capturingRawLogStorage{}
+	p := &mockProtocol{id: "test_protocol", hits: []*hits.Hit{}}
+	server := NewServer(
+		storage,
+		rawLogStorage,
+		HitValidatingRuleSet(1024*128, properties.NewStaticSettingsRegistry([]properties.Settings{{
+			PropertyID: "test_property_id",
+			ProtocolID: "test_protocol",
+		}})),
+		[]protocol.Protocol{p},
+		8080,
+		WithTrustAllProxies(),
+	)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetHost("example.com")
+	ctx.Request.Header.SetHost("example.com")
+	ctx.Request.Header.Set("X-Real-IP", "192.168.1.123")
+	ctx.URI().SetPath("/collect")
+
+	// when
+	server.handleRequest(context.Background(), ctx, p)
+
+	// then
+	assert.Equal(t, fasthttp.StatusNoContent, ctx.Response.StatusCode())
+	assert.Empty(t, storage.hits)
+	assert.Len(t, rawLogStorage.requests, 1)
+	assert.Equal(t, "192.168.1.123", rawLogStorage.requests[0].IP)
 }

--- a/pkg/splitter/filter_test.go
+++ b/pkg/splitter/filter_test.go
@@ -224,6 +224,39 @@ func TestFilterModifierAllowActive(t *testing.T) {
 	assert.Equal(t, "100.127.255.254", sessions[0].Events[1].Values["ip_address"])
 }
 
+func TestFilterModifierUsesMaskedIPAddressValue(t *testing.T) {
+	// given
+	config := properties.FiltersConfig{
+		Fields: []string{"ip_address"},
+		Conditions: []properties.ConditionConfig{
+			{
+				Name:       "masked_only",
+				Type:       properties.FilterTypeAllow,
+				TestMode:   false,
+				Expression: `ip_address == "192.168.1.0"`,
+			},
+		},
+	}
+	modifier, err := NewFilter(config)
+	require.NoError(t, err)
+
+	session := &schema.Session{
+		Events: []*schema.Event{
+			{Values: map[string]any{"ip_address": "192.168.1.0"}, Metadata: make(map[string]any)},
+			{Values: map[string]any{"ip_address": "192.168.1.123"}, Metadata: make(map[string]any)},
+		},
+	}
+
+	// when
+	sessions, err := modifier.Split(session)
+
+	// then
+	require.NoError(t, err)
+	assert.Len(t, sessions, 1)
+	assert.Len(t, sessions[0].Events, 1)
+	assert.Equal(t, "192.168.1.0", sessions[0].Events[0].Values["ip_address"])
+}
+
 func TestFilterModifierTestingMode(t *testing.T) {
 	// given
 	config := properties.FiltersConfig{


### PR DESCRIPTION
## Summary
- add property-level ip_masking_level setting with CLI/env/YAML wiring
- validate masking levels and reject masking with session-stamp joining
- apply registry-driven IP masking during receiver hit processing
- ensure downstream geo/filter/IP column paths use the masked IP

## Verification
- go test ./...
- ~/go/bin/golangci-lint run ./... -c .golangci.yml

## Notes
- Created from fresh origin/master and cherry-picked only IP-masking commits, excluding session geo/device commits.