### PR TITLE
Loosen IP masking session stamp validation

### DIFF
--- a/pkg/cmd/property_settings_test.go
+++ b/pkg/cmd/property_settings_test.go
@@ -210,7 +210,7 @@ func TestPropertySettings_IPMaskingSessionStampConflictFromConfigPanics(t *testi
 	configPath := writeConfigFile(t, `
 property:
   settings:
-    ip_masking_level: 1
+    ip_masking_level: 4
 sessions:
   join_by_session_stamp: true
 `)

--- a/pkg/properties/validation.go
+++ b/pkg/properties/validation.go
@@ -12,8 +12,8 @@ func ValidateSettings(settings *Settings) error {
 		return fmt.Errorf("ip masking level must be between 0 and 4: %d", settings.IPMaskingLevel)
 	}
 
-	if settings.IPMaskingLevel > 0 && settings.SessionJoinBySessionStamp {
-		return fmt.Errorf("session join by session stamp must be disabled when ip masking level is non-zero")
+	if settings.IPMaskingLevel == 4 && settings.SessionJoinBySessionStamp {
+		return fmt.Errorf("session join by session stamp must be disabled when ip masking is maximal")
 	}
 
 	return nil

--- a/pkg/properties/validation_test.go
+++ b/pkg/properties/validation_test.go
@@ -44,12 +44,19 @@ func TestValidateSettings(t *testing.T) {
 			wantErr:  "ip masking level must be between 0 and 4: 5",
 		},
 		{
-			name: "masking conflicts with session stamp join",
+			name: "partial masking allows session stamp join",
 			settings: &Settings{
 				IPMaskingLevel:            1,
 				SessionJoinBySessionStamp: true,
 			},
-			wantErr: "session join by session stamp must be disabled when ip masking level is non-zero",
+		},
+		{
+			name: "maximal masking conflicts with session stamp join",
+			settings: &Settings{
+				IPMaskingLevel:            4,
+				SessionJoinBySessionStamp: true,
+			},
+			wantErr: "session join by session stamp must be disabled when ip masking is maximal",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Allow session stamp joins with non-maximal IP masking
- Keep the conflict only when IP masking is maximal
- Update property validation and config tests for the new boundary

## Tests
- go test ./...
- ~/go/bin/golangci-lint run ./... -c .golangci.yml