### PR TITLE
Allow session stamp with partial IP masking

### DIFF
--- a/pkg/cmd/property_settings_test.go
+++ b/pkg/cmd/property_settings_test.go
@@ -204,13 +204,13 @@ sessions:
 	})
 }
 
-func TestPropertySettings_IPMaskingSessionStampConflictFromConfigPanics(t *testing.T) {
+func TestPropertySettings_FullIPMaskingSessionStampConflictFromConfigPanics(t *testing.T) {
 	// given
 	setDeliveryModeForTest(t, "")
 	configPath := writeConfigFile(t, `
 property:
   settings:
-    ip_masking_level: 1
+    ip_masking_level: 4
 sessions:
   join_by_session_stamp: true
 `)

--- a/pkg/properties/validation.go
+++ b/pkg/properties/validation.go
@@ -12,8 +12,8 @@ func ValidateSettings(settings *Settings) error {
 		return fmt.Errorf("ip masking level must be between 0 and 4: %d", settings.IPMaskingLevel)
 	}
 
-	if settings.IPMaskingLevel > 0 && settings.SessionJoinBySessionStamp {
-		return fmt.Errorf("session join by session stamp must be disabled when ip masking level is non-zero")
+	if settings.IPMaskingLevel == 4 && settings.SessionJoinBySessionStamp {
+		return fmt.Errorf("session join by session stamp must be disabled when ip masking level is 4")
 	}
 
 	return nil

--- a/pkg/properties/validation_test.go
+++ b/pkg/properties/validation_test.go
@@ -44,12 +44,19 @@ func TestValidateSettings(t *testing.T) {
 			wantErr:  "ip masking level must be between 0 and 4: 5",
 		},
 		{
-			name: "masking conflicts with session stamp join",
+			name: "partial masking is valid with session stamp join",
 			settings: &Settings{
 				IPMaskingLevel:            1,
 				SessionJoinBySessionStamp: true,
 			},
-			wantErr: "session join by session stamp must be disabled when ip masking level is non-zero",
+		},
+		{
+			name: "full masking conflicts with session stamp join",
+			settings: &Settings{
+				IPMaskingLevel:            4,
+				SessionJoinBySessionStamp: true,
+			},
+			wantErr: "session join by session stamp must be disabled when ip masking level is 4",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- allow session-stamp joining with IP masking levels 0 through 3
- keep validation failure for full IP masking level 4
- update settings validation and config tests

## Tests
- go test ./pkg/properties
- go test ./pkg/cmd