### PR TITLE
fix: disable S3 upload checksums

### DIFF
--- a/pkg/cmd/objectstorage.go
+++ b/pkg/cmd/objectstorage.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go/middleware"
 	"github.com/urfave/cli/v3"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/gcsblob"
@@ -67,6 +68,8 @@ func createS3BucketWithFlags(
 			),
 		)
 		o.UsePathStyle = true
+		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+		o.APIOptions = append(o.APIOptions, disableS3UploadChecksums)
 	})
 
 	bucketName := c.String(flags.S3Bucket.Name)
@@ -97,6 +100,35 @@ func createS3BucketWithFlags(
 		return nil, nil, fmt.Errorf("open s3 bucket: %w", err)
 	}
 	return bucket, bucket.Close, nil
+}
+
+func disableS3UploadChecksums(stack *middleware.Stack) error {
+	return stack.Initialize.Add(
+		middleware.InitializeMiddlewareFunc(
+			"d8aDisableS3UploadChecksums",
+			func(
+				ctx context.Context,
+				in middleware.InitializeInput,
+				next middleware.InitializeHandler,
+			) (middleware.InitializeOutput, middleware.Metadata, error) {
+				clearS3ChecksumAlgorithm(in.Parameters)
+
+				return next.HandleInitialize(ctx, in)
+			},
+		),
+		middleware.Before,
+	)
+}
+
+func clearS3ChecksumAlgorithm(parameters any) {
+	switch input := parameters.(type) {
+	case *s3.PutObjectInput:
+		input.ChecksumAlgorithm = ""
+	case *s3.CreateMultipartUploadInput:
+		input.ChecksumAlgorithm = ""
+	case *s3.UploadPartInput:
+		input.ChecksumAlgorithm = ""
+	}
 }
 
 // nolint:funlen // straightforward setup

--- a/pkg/cmd/objectstorage_test.go
+++ b/pkg/cmd/objectstorage_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClearS3ChecksumAlgorithm(t *testing.T) {
+	t.Run("put object", func(t *testing.T) {
+		// given
+		input := &s3.PutObjectInput{ChecksumAlgorithm: types.ChecksumAlgorithmCrc32}
+
+		// when
+		clearS3ChecksumAlgorithm(input)
+
+		// then
+		assert.Empty(t, input.ChecksumAlgorithm)
+	})
+
+	t.Run("create multipart upload", func(t *testing.T) {
+		// given
+		input := &s3.CreateMultipartUploadInput{ChecksumAlgorithm: types.ChecksumAlgorithmCrc32}
+
+		// when
+		clearS3ChecksumAlgorithm(input)
+
+		// then
+		assert.Empty(t, input.ChecksumAlgorithm)
+	})
+
+	t.Run("upload part", func(t *testing.T) {
+		// given
+		input := &s3.UploadPartInput{ChecksumAlgorithm: types.ChecksumAlgorithmCrc32}
+
+		// when
+		clearS3ChecksumAlgorithm(input)
+
+		// then
+		assert.Empty(t, input.ChecksumAlgorithm)
+	})
+
+	t.Run("unrelated input", func(t *testing.T) {
+		// given
+		input := &s3.GetObjectInput{}
+
+		// when
+		clearS3ChecksumAlgorithm(input)
+
+		// then
+		assert.NotNil(t, input)
+	})
+}


### PR DESCRIPTION
## Summary
- set S3 request checksum calculation to when_required for S3-compatible object storage
- clear transfermanager's default CRC32 upload checksum algorithm before PutObject/CreateMultipartUpload/UploadPart requests are signed
- add focused tests for checksum stripping

## Context
The newer AWS SDK/transfermanager versions add checksum behavior that can break S3-compatible providers such as UpCloud. Go Cloud's s3blob uses transfermanager internally, which defaults upload checksum algorithms to CRC32.

## Verification
- go test ./...
- ~/go/bin/golangci-lint run ./... -c .golangci.yml