### PR TITLE
Return safe protocol mismatch details to tracker clients

### DIFF
--- a/pkg/receiver/errors.go
+++ b/pkg/receiver/errors.go
@@ -1,0 +1,23 @@
+package receiver
+
+// safeClientError is safe to return to tracker clients.
+type safeClientError interface {
+	error
+	clientMessage() string
+}
+
+type clientError struct {
+	message string
+}
+
+func (e *clientError) Error() string {
+	return e.message
+}
+
+func (e *clientError) clientMessage() string {
+	return e.message
+}
+
+func newClientError(message string) safeClientError {
+	return &clientError{message: message}
+}

--- a/pkg/receiver/server.go
+++ b/pkg/receiver/server.go
@@ -2,6 +2,7 @@ package receiver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/textproto"
@@ -204,6 +205,11 @@ func (s *Server) handleRequest(
 	hits, err := s.createHits(ctx, selectedProtocol)
 	if err != nil {
 		logrus.WithError(err).Warn("failed to create hits from request")
+		var clientErr safeClientError
+		if errors.As(err, &clientErr) {
+			ctx.Error(clientErr.clientMessage(), fasthttp.StatusBadRequest)
+			return
+		}
 		ctx.Error("Bad Request", fasthttp.StatusBadRequest)
 		return
 	}

--- a/pkg/receiver/server_test.go
+++ b/pkg/receiver/server_test.go
@@ -263,7 +263,7 @@ func TestHandleRequest_ErrorResponsesDoNotLeakInternalDetails(t *testing.T) {
 	}
 }
 
-func TestHandleRequest_ValidationErrorDoesNotLeakDetails(t *testing.T) {
+func TestHandleRequest_ProtocolMismatchReturnsSafeDetails(t *testing.T) {
 	// given — use a protocol whose property ID doesn't match settings,
 	// triggering PropertyProtocolMatchesTheEndpointProtocol validation error.
 	storage := &mockStorage{}
@@ -296,11 +296,35 @@ func TestHandleRequest_ValidationErrorDoesNotLeakDetails(t *testing.T) {
 	// then
 	assert.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode())
 	body := string(ctx.Response.Body())
-	assert.Contains(t, body, "Bad Request")
+	assert.Contains(t, body, "property protocol test_protocol does not match endpoint protocol wrong_protocol")
 	assert.NotContains(t, body, "test_property_id")
-	assert.NotContains(t, body, "test_protocol")
-	assert.NotContains(t, body, "wrong_protocol")
-	assert.NotContains(t, body, "does not match")
+}
+
+func TestHandleRequest_SettingsErrorDoesNotLeakDetails(t *testing.T) {
+	// given
+	storage := &mockStorage{}
+	p := &mockProtocol{id: "test_protocol"}
+	server := NewServer(
+		storage,
+		NewDummyRawLogStorage(),
+		HitValidatingRuleSet(1024*128, settingsRegistryStub{err: fmt.Errorf("settings database unavailable")}),
+		[]protocol.Protocol{p},
+		8080,
+		WithTrustAllProxies(),
+	)
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetHost("example.com")
+	ctx.Request.Header.SetHost("example.com")
+	ctx.Request.Header.Set("X-Real-IP", "192.168.1.1")
+	ctx.Request.Header.Set("User-Agent", "test-agent")
+	ctx.URI().SetPath("/collect")
+
+	// when
+	server.handleRequest(context.Background(), ctx, p)
+
+	// then
+	assert.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode())
+	assert.Equal(t, "Bad Request", string(ctx.Response.Body()))
 }
 
 func TestHandleRequest_MasksIPBeforeStorageAndRawLog(t *testing.T) {

--- a/pkg/receiver/validate.go
+++ b/pkg/receiver/validate.go
@@ -139,7 +139,11 @@ func PropertyProtocolMatchesTheEndpointProtocol(settings properties.SettingsRegi
 			return err
 		}
 		if settings.ProtocolID != p.ID() {
-			return fmt.Errorf("property protocol %s does not match endpoint protocol %s", settings.ProtocolID, p.ID())
+			return newClientError(fmt.Sprintf(
+				"property protocol %s does not match endpoint protocol %s",
+				settings.ProtocolID,
+				p.ID(),
+			))
 		}
 		return nil
 	})


### PR DESCRIPTION
## Summary
- add a receiver-local marker for errors that are safe to expose to tracker clients
- return property/endpoint protocol mismatch details with the existing 400 response
- keep parsing, settings lookup, processing, and storage errors generic

Closes #625