### PR TITLE
ci: group Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@ updates:
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
+    groups:
+      security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
     labels:
       - "go"
 
@@ -27,5 +32,10 @@ updates:
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
+    groups:
+      security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
     labels:
       - "javascript"


### PR DESCRIPTION
## Summary

- group all Go security updates into one Dependabot PR
- group all npm security updates across the three configured workspaces into one Dependabot PR
- retain the existing cross-ecosystem group for regular version updates

GitHub supports cross-ecosystem grouping for version updates only. Security updates can be grouped per package manager, so this reduces the current 17 security PRs to two (Go and npm) after merge.

## Validation

- `npx --yes prettier@3.6.2 .github/dependabot.yml --check`