### PR TITLE
ci: add seven-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ multi-ecosystem-groups:
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
+    cooldown:
+      default-days: 7
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
@@ -29,6 +31,8 @@ updates:
       - "/docs"
       - "/js/ga4-duplicator"
       - "/js/web-tracker"
+    cooldown:
+      default-days: 7
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"


### PR DESCRIPTION
## Summary

- wait seven days after release before proposing Go module version updates
- wait seven days after release before proposing npm version updates across all workspaces
- keep security updates immediate; GitHub does not apply cooldown to security updates

## Validation

- `npx --yes prettier@3.6.2 .github/dependabot.yml --check`